### PR TITLE
Hounslow ch38 correctly display new org admin update requests

### DIFF
--- a/app/Models/Scopes/UpdateRequestScopes.php
+++ b/app/Models/Scopes/UpdateRequestScopes.php
@@ -134,7 +134,12 @@ CASE `update_requests`.`updateable_type`
         LIMIT 1
     )
     WHEN "{$organisationSignUpForm}" THEN (
-        `update_requests`.`data`->>"$.organisation.name"
+        IF(`update_requests`.`data`->>"$.organisation.id", (
+            SELECT `organisations`.`name`
+            FROM `organisations`
+            WHERE `update_requests`.`data`->>"$.organisation.id" = `organisations`.`id`
+            LIMIT 1
+        ), `update_requests`.`data`->>"$.organisation.name")
     )
 END
 EOT;


### PR DESCRIPTION
### Summary

https://app.clubhouse.io/ayup-digital-ltd/story/38/correctly-display-new-org-admin-update-requests

Display existing Organisation names in update requests where an admin signup is using an existing organisation rather than creating a new one.

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

NA

### Notes

NA
