### PR TITLE
Return context correct message for global admin

### DIFF
--- a/app/Http/Responses/UpdateRequestReceived.php
+++ b/app/Http/Responses/UpdateRequestReceived.php
@@ -39,7 +39,7 @@ class UpdateRequestReceived implements Responsable
     public function toResponse($request)
     {
         return response()->json([
-            'message' => 'The update request has been received and needs to be reviewed',
+            'message' => $this->updateRequest->isApproved() ? __('updates.pre-approved') : __('updates.pending'),
             'id' => $this->updateRequest->id,
             'data' => $this->updateRequest->getUpdateable()->getData(
                 $this->updateRequest->data

--- a/resources/lang/en/updates.php
+++ b/resources/lang/en/updates.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Update Request Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used during updates to entites and form
+    | part of the update rquest cycle.
+    |
+     */
+
+    'pending' => 'The update request has been received and needs to be reviewed',
+    'pre-approved' => 'The update request has been received and approved',
+
+];

--- a/tests/Feature/OrganisationsTest.php
+++ b/tests/Feature/OrganisationsTest.php
@@ -216,6 +216,7 @@ class OrganisationsTest extends TestCase
 
         $response->assertStatus(Response::HTTP_OK);
         $response->assertJsonFragment(['data' => $payload]);
+        $response->assertJsonFragment(['message' => __('updates.pre-approved')]);
 
         $this->assertDatabaseHas((new UpdateRequest())->getTable(), [
             'user_id' => $user->id,


### PR DESCRIPTION
### Summary

https://app.clubhouse.io/ayup-digital-ltd/story/197/global-admins-to-skip-update-request-flow

Simple intervention to show different messages following updates based on update request approval status.

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

NA

### Notes

NA
