### PR TITLE
Settings video_url field is optional

### DIFF
--- a/app/Docs/Schemas/Setting/SettingSchema.php
+++ b/app/Docs/Schemas/Setting/SettingSchema.php
@@ -42,7 +42,7 @@ class SettingSchema extends Schema
         $about = Schema::object('about')->properties(
             Schema::string('title'),
             Schema::string('content')->format('markdown'),
-            Schema::string('video_url')
+            Schema::string('video_url')->nullable()
         );
 
         $contact = Schema::object('contact')->properties(

--- a/app/Docs/Schemas/Setting/UpdateSettingSchema.php
+++ b/app/Docs/Schemas/Setting/UpdateSettingSchema.php
@@ -53,7 +53,7 @@ class UpdateSettingSchema extends Schema
             ->properties(
                 Schema::string('title'),
                 Schema::string('content')->format('markdown')
-        );
+            );
 
         $privacyPolicy = Schema::object('privacy_policy')
             ->required(
@@ -68,8 +68,7 @@ class UpdateSettingSchema extends Schema
         $about = Schema::object('about')
             ->required(
                 'title',
-                'content',
-                'video_url'
+                'content'
             )
             ->properties(
                 Schema::string('title'),

--- a/app/Http/Controllers/Core/V1/SettingController.php
+++ b/app/Http/Controllers/Core/V1/SettingController.php
@@ -84,8 +84,8 @@ class SettingController extends Controller
                             'banner' => [
                                 'title' => $request->input('cms.frontend.banner.title'),
                                 'content' => $request->filled('cms.frontend.banner.content')
-                                    ? sanitize_markdown($request->input('cms.frontend.banner.content'))
-                                    : null,
+                                ? sanitize_markdown($request->input('cms.frontend.banner.content'))
+                                : null,
                                 'button_text' => $request->input('cms.frontend.banner.button_text'),
                                 'button_url' => $request->input('cms.frontend.banner.button_url'),
                                 'image_file_id' => $request->input(

--- a/app/Http/Requests/Setting/UpdateRequest.php
+++ b/app/Http/Requests/Setting/UpdateRequest.php
@@ -57,7 +57,7 @@ class UpdateRequest extends FormRequest
             'cms.frontend.about' => ['required', 'array'],
             'cms.frontend.about.title' => ['required', 'string'],
             'cms.frontend.about.content' => ['required', 'string'],
-            'cms.frontend.about.video_url' => ['required', 'string', 'url', new VideoEmbed()],
+            'cms.frontend.about.video_url' => ['nullable', 'string', 'url', new VideoEmbed()],
 
             'cms.frontend.contact' => ['required', 'array'],
             'cms.frontend.contact.title' => ['required', 'string'],

--- a/tests/Feature/SettingsTest.php
+++ b/tests/Feature/SettingsTest.php
@@ -563,6 +563,94 @@ class SettingsTest extends TestCase
         });
     }
 
+    /**
+     * @test
+     */
+    public function video_url_is_optional()
+    {
+        Passport::actingAs(
+            factory(User::class)->create()->makeGlobalAdmin()
+        );
+
+        $settingsData = [
+            'cms' => [
+                'frontend' => [
+                    'global' => [
+                        'footer_title' => 'data/cms/frontend/global/footer_title',
+                        'footer_content' => 'data/cms/frontend/global/footer_content',
+                        'contact_phone' => 'data/cms/frontend/global/contact_phone',
+                        'contact_email' => 'example@example.com',
+                        'facebook_handle' => 'data/cms/frontend/global/facebook_handle',
+                        'twitter_handle' => 'data/cms/frontend/global/twitter_handle',
+                    ],
+                    'home' => [
+                        'search_title' => 'data/cms/frontend/home/search_title',
+                        'categories_title' => 'data/cms/frontend/home/categories_title',
+                        'personas_title' => 'data/cms/frontend/home/personas_title',
+                        'personas_content' => 'data/cms/frontend/home/personas_content',
+                    ],
+                    'terms_and_conditions' => [
+                        'title' => 'data/cms/frontend/terms_and_conditions/title',
+                        'content' => 'data/cms/frontend/terms_and_conditions/content',
+                    ],
+                    'privacy_policy' => [
+                        'title' => 'data/cms/frontend/privacy_policy/title',
+                        'content' => 'data/cms/frontend/privacy_policy/content',
+                    ],
+                    'about' => [
+                        'title' => 'data/cms/frontend/about/title',
+                        'content' => 'data/cms/frontend/about/content',
+                        'video_url' => 'https://www.youtube.com/random-video-slug',
+                    ],
+                    'contact' => [
+                        'title' => 'data/cms/frontend/contact/title',
+                        'content' => 'data/cms/frontend/contact/content',
+                    ],
+                    'get_involved' => [
+                        'title' => 'data/cms/frontend/get_involved/title',
+                        'content' => 'data/cms/frontend/get_involved/content',
+                    ],
+                    'favourites' => [
+                        'title' => 'data/cms/frontend/favourites/title',
+                        'content' => 'data/cms/frontend/favourites/content',
+                    ],
+                    'banner' => [
+                        'title' => 'data/cms/frontend/banner/title',
+                        'content' => 'data/cms/frontend/banner/content',
+                        'button_text' => 'button_text',
+                        'button_url' => 'https://example.com/data/cms/frontend/banner/button_url',
+                    ],
+                ],
+            ],
+        ];
+
+        $response = $this->putJson('/core/v1/settings', $settingsData);
+
+        $response->assertStatus(Response::HTTP_OK);
+
+        $response->assertJsonFragment([
+            'about' => [
+                'title' => 'data/cms/frontend/about/title',
+                'content' => 'data/cms/frontend/about/content',
+                'video_url' => 'https://www.youtube.com/random-video-slug',
+            ],
+        ]);
+
+        $settingsData['cms']['frontend']['about']['video_url'] = null;
+
+        $response = $this->putJson('/core/v1/settings', $settingsData);
+
+        $response->assertStatus(Response::HTTP_OK);
+
+        $response->assertJsonFragment([
+            'about' => [
+                'title' => 'data/cms/frontend/about/title',
+                'content' => 'data/cms/frontend/about/content',
+                'video_url' => null,
+            ],
+        ]);
+    }
+
     /*
      * CMS / Frontend / Banner.
      */


### PR DESCRIPTION
### Summary

https://app.clubhouse.io/ayup-digital-ltd/story/187/make-video-field-for-about-page-in-cms-optional

Video field in settings was required and is now optional

### Development checklist

- [x] Changes have been made to the API?
  - [x] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

NA

### Notes

NA
