### PR TITLE
Feature/hounslow ch306 endpoint added for eligibility type taxonomies

### DIFF
--- a/app/Docs/OpenApi.php
+++ b/app/Docs/OpenApi.php
@@ -85,6 +85,7 @@ class OpenApi extends BaseOpenApi implements Responsable
                 Paths\Taxonomies\Organisations\TaxonomyOrganisationsRootPath::create(),
                 Paths\Taxonomies\Organisations\TaxonomyOrganisationsIndexPath::create(),
                 Paths\Taxonomies\Organisations\TaxonomyOrganisationsNestedPath::create(),
+                Paths\Taxonomies\ServiceEligibilities\TaxonomyServiceEligibilitiesRootPath::create(),
                 Paths\Thesaurus\ThesaurusRootPath::create(),
                 Paths\UpdateRequests\UpdateRequestsRootPath::create(),
                 Paths\UpdateRequests\UpdateRequestsIndexPath::create(),

--- a/app/Http/Controllers/Core/V1/TaxonomyServiceEligibilityController.php
+++ b/app/Http/Controllers/Core/V1/TaxonomyServiceEligibilityController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers\Core\V1;
+
+use App\Events\EndpointHit;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\TaxonomyServiceEligibility\IndexRequest;
+use App\Http\Resources\TaxonomyCategoryResource;
+use App\Models\Taxonomy;
+use Spatie\QueryBuilder\QueryBuilder;
+
+class TaxonomyServiceEligibilityController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @param \App\Http\Requests\TaxonomyServiceEligibility\IndexRequest $request
+     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     */
+    public function index(IndexRequest $request)
+    {
+        $baseQuery = Taxonomy::query()
+            ->topLevelServiceEligibilities()
+            ->with('children.children.children.children.children.children')
+            ->orderBy('order');
+
+        $serviceEligibilities = QueryBuilder::for($baseQuery)
+            ->get();
+
+        event(EndpointHit::onRead($request, 'Viewed all taxonomy service eligibilities'));
+
+        return TaxonomyCategoryResource::collection($serviceEligibilities);
+    }
+}

--- a/app/Http/Requests/TaxonomyServiceEligibility/IndexRequest.php
+++ b/app/Http/Requests/TaxonomyServiceEligibility/IndexRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\TaxonomyServiceEligibility;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class IndexRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Models/Scopes/TaxonomyScopes.php
+++ b/app/Models/Scopes/TaxonomyScopes.php
@@ -23,4 +23,13 @@ trait TaxonomyScopes
     {
         return $query->where('parent_id', static::organisation()->id);
     }
+
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeTopLevelServiceEligibilities(Builder $query): Builder
+    {
+        return $query->where('parent_id', static::serviceEligibility()->id);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -172,7 +172,7 @@ Route::prefix('/core/v1')
                 ]);
 
             // Taxonomy Service Eligibility.
-            Route::get('/taxonomies/service-eligibility', 'TaxonomyServiceEligibilityController@index');
+            Route::get('/taxonomies/service-eligibilities', 'TaxonomyServiceEligibilityController@index');
 
             // Thesaurus.
             Route::get('/thesaurus', 'ThesaurusController@index')

--- a/routes/api.php
+++ b/routes/api.php
@@ -171,6 +171,9 @@ Route::prefix('/core/v1')
                     'destroy' => 'taxonomy-organisations.destroy',
                 ]);
 
+            // Taxonomy Service Eligibility.
+            Route::get('/taxonomies/service-eligibility', 'TaxonomyServiceEligibilityController@index');
+
             // Thesaurus.
             Route::get('/thesaurus', 'ThesaurusController@index')
                 ->name('thesaurus.index');

--- a/tests/Feature/TaxonomyServiceEligibilityTest.php
+++ b/tests/Feature/TaxonomyServiceEligibilityTest.php
@@ -27,7 +27,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
 
     public function test_guest_can_list_them()
     {
-        $response = $this->json('GET', '/core/v1/taxonomies/service-eligibility');
+        $response = $this->json('GET', '/core/v1/taxonomies/service-eligibilities');
 
         $taxonomyCount = Taxonomy::serviceEligibility()->children()->count();
 
@@ -52,7 +52,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
     {
         $this->fakeEvents();
 
-        $this->json('GET', '/core/v1/taxonomies/service-eligibility');
+        $this->json('GET', '/core/v1/taxonomies/service-eligibilities');
 
         Event::assertDispatched(EndpointHit::class, function (EndpointHit $event) {
             return ($event->getAction() === Audit::ACTION_READ);

--- a/tests/Feature/TaxonomyServiceEligibilityTest.php
+++ b/tests/Feature/TaxonomyServiceEligibilityTest.php
@@ -2,9 +2,13 @@
 
 namespace Tests\Feature;
 
+use App\Events\EndpointHit;
+use App\Models\Audit;
 use App\Models\Service;
 use App\Models\SocialMedia;
 use App\Models\Taxonomy;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
@@ -15,6 +19,44 @@ class TaxonomyServiceEligibilityTest extends TestCase
     {
         parent::setUp();
         $this->generateServiceEligibilityTaxonomy();
+    }
+
+    /*
+     * List all the category taxonomies.
+     */
+
+    public function test_guest_can_list_them()
+    {
+        $response = $this->json('GET', '/core/v1/taxonomies/service-eligibility');
+
+        $taxonomyCount = Taxonomy::serviceEligibility()->children()->count();
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJsonCount($taxonomyCount, 'data');
+        $response->assertJsonStructure([
+            'data' => [
+                [
+                    'id',
+                    'parent_id',
+                    'name',
+                    'order',
+                    'children' => [],
+                    'created_at',
+                    'updated_at',
+                ],
+            ],
+        ]);
+    }
+
+    public function test_audit_created_when_listed()
+    {
+        $this->fakeEvents();
+
+        $this->json('GET', '/core/v1/taxonomies/service-eligibility');
+
+        Event::assertDispatched(EndpointHit::class, function (EndpointHit $event) {
+            return ($event->getAction() === Audit::ACTION_READ);
+        });
     }
 
     public function test_criteria_property_returns_comma_separated_service_eligibilities()
@@ -33,11 +75,11 @@ class TaxonomyServiceEligibilityTest extends TestCase
                 'language' => 'Language taxonomy child,custom language',
                 'ethnicity' => 'Ethnicity taxonomy child,custom ethnicity',
                 'other' => 'custom other',
-            ]
+            ],
         ]);
     }
 
-    private function  createService()
+    private function createService()
     {
         $service = factory(Service::class)->create();
 
@@ -47,21 +89,21 @@ class TaxonomyServiceEligibilityTest extends TestCase
             'description' => 'This is a test description',
             'order' => 1,
         ]);
-        
+
         $service->offerings()->create([
             'offering' => 'Weekly club',
             'order' => 1,
         ]);
-        
+
         $service->socialMedias()->create([
             'type' => SocialMedia::TYPE_INSTAGRAM,
             'url' => 'https://www.instagram.com/ayupdigital/',
         ]);
 
         // Loop through each top level child of service eligibility taxonomy
-        Taxonomy::serviceEligibility()->children->each((function($topLevelChild) use ($service) {
+        Taxonomy::serviceEligibility()->children->each((function ($topLevelChild) use ($service) {
             // And for each top level child, attach one of its children to the service
-            $topLevelChild->children->each(function($serviceEligibilityTaxonomyParent) use ($service) {
+            $topLevelChild->children->each(function ($serviceEligibilityTaxonomyParent) use ($service) {
                 $service->serviceEligibilities()->create([
                     'id' => (string) Str::uuid(),
                     'taxonomy_id' => $serviceEligibilityTaxonomyParent->id,
@@ -78,7 +120,6 @@ class TaxonomyServiceEligibilityTest extends TestCase
         $service->eligibility_language_custom = 'custom language';
         $service->eligibility_ethnicity_custom = 'custom ethnicity';
         $service->eligibility_other_custom = 'custom other';
-
 
         $service->save();
         return $service;
@@ -126,7 +167,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
                 'name' => 'Ethnicity',
                 'order' => 7,
                 'depth' => 1,
-            ]
+            ],
         ];
 
         Taxonomy::serviceEligibility()


### PR DESCRIPTION
### Summary

https://app.clubhouse.io/ayup-digital-ltd/story/306/endpoint-added-for-eligibility-type-taxonomies

Add an index endpoint for service eligibility taxonomies that returns a non-paginated list

### Development checklist

- [x] Changes have been made to the API?
  - [x] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

NA

### Notes

NA
