### PR TITLE
Feature/hounslow ch288 nest new taxonomies under lga top level taxonomy

### DIFF
--- a/app/Rules/CanUpdateCategoryTaxonomyRelationships.php
+++ b/app/Rules/CanUpdateCategoryTaxonomyRelationships.php
@@ -67,8 +67,8 @@ class CanUpdateCategoryTaxonomyRelationships implements Rule
             ->taxonomies()
             ->pluck(table(Taxonomy::class, 'id'))
             ->toArray();
-        $existingTaxonomies = Arr::sort($existingTaxonomyIds);
-        $newTaxonomies = Arr::sort($value);
+        $existingTaxonomies = array_values(Arr::sort($existingTaxonomyIds));
+        $newTaxonomies = array_values(Arr::sort($value));
         $taxonomiesUnchanged = $existingTaxonomies === $newTaxonomies;
 
         return $taxonomiesUnchanged;

--- a/database/factories/ServiceFactory.php
+++ b/database/factories/ServiceFactory.php
@@ -89,5 +89,5 @@ $factory->afterCreatingState(Service::class, 'withEligibilityTaxonomies', functi
 });
 
 $factory->afterCreatingState(Service::class, 'withCategoryTaxonomies', function (Service $service) {
-    $service->syncTaxonomyRelationships(collect([factory(Taxonomy::class)->create()->id]));
+    $service->syncTaxonomyRelationships(collect([factory(Taxonomy::class)->create()]));
 });

--- a/database/factories/ServiceFactory.php
+++ b/database/factories/ServiceFactory.php
@@ -89,5 +89,5 @@ $factory->afterCreatingState(Service::class, 'withEligibilityTaxonomies', functi
 });
 
 $factory->afterCreatingState(Service::class, 'withCategoryTaxonomies', function (Service $service) {
-    $service->syncTaxonomyRelationships(collect([Taxonomy::category()->children()->firstOrFail()]));
+    $service->syncTaxonomyRelationships(collect([factory(Taxonomy::class)->create()->id]));
 });

--- a/database/factories/TaxonomyFactory.php
+++ b/database/factories/TaxonomyFactory.php
@@ -8,7 +8,7 @@ $factory->define(Taxonomy::class, function (Faker $faker) {
 
     return [
         'name' => $name,
-        'parent_id' => Taxonomy::category()->id,
+        'parent_id' => Taxonomy::category()->children()->first()->id,
         'order' => 0,
         'depth' => 1,
     ];

--- a/database/migrations/2021_06_04_140343_add_lga_standards_top_level_category_taxonomy_to_taxonomies_table.php
+++ b/database/migrations/2021_06_04_140343_add_lga_standards_top_level_category_taxonomy_to_taxonomies_table.php
@@ -1,0 +1,92 @@
+<?php
+
+use App\Models\ServiceTaxonomy;
+use App\Models\Taxonomy;
+use Carbon\Carbon;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+class AddLgaStandardsTopLevelCategoryTaxonomyToTaxonomiesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $categoryId = Taxonomy::category()->id;
+        $lgaStandardsId = uuid();
+        $nowDateTimeString = Carbon::now()->toDateTimeString();
+
+        // Create LGA Standards Taxonomy as child of Category
+        DB::table((new Taxonomy())->getTable())->insert(
+            [
+                'id' => $lgaStandardsId,
+                'parent_id' => $categoryId,
+                'name' => 'LGA Standards',
+                'order' => 0,
+                'depth' => 1,
+                'created_at' => $nowDateTimeString,
+                'updated_at' => $nowDateTimeString,
+            ]
+        );
+
+        // Move all direct children of Category to LGA Standards
+        DB::table((new Taxonomy())->getTable())
+            ->where('parent_id', $categoryId)
+            ->where('id', '<>', $lgaStandardsId)
+            ->update(['parent_id' => $lgaStandardsId]);
+
+        Taxonomy::category()->updateDepth();
+
+        // Get the Services related to the now children of LGA Standards
+        $serviceIds = DB::table((new ServiceTaxonomy())->getTable())
+            ->distinct()
+            ->whereIn('taxonomy_id', function ($query) use ($lgaStandardsId) {
+                $query->select('id')
+                    ->from((new Taxonomy())->getTable())
+                    ->where('parent_id', $lgaStandardsId);
+            })->pluck('service_id');
+
+        // Relate those Services to LGA Standards as well
+        DB::table((new ServiceTaxonomy())->getTable())
+            ->insert(array_map(function ($serviceId) use ($lgaStandardsId, $nowDateTimeString) {
+                return [
+                    'id' => uuid(),
+                    'service_id' => $serviceId,
+                    'taxonomy_id' => $lgaStandardsId,
+                    'created_at' => $nowDateTimeString,
+                    'updated_at' => $nowDateTimeString,
+                ];
+            }, $serviceIds->all()));
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $categoryId = Taxonomy::category()->id;
+        $lgaStandardsId = DB::table((new Taxonomy())->getTable())
+            ->where('parent_id', $categoryId)
+            ->where('name', 'LGA Standards')
+            ->value('id');
+
+        DB::table((new ServiceTaxonomy())->getTable())
+            ->where('taxonomy_id', $lgaStandardsId)
+            ->delete();
+
+        DB::table((new Taxonomy())->getTable())
+            ->where('parent_id', $lgaStandardsId)
+            ->update(['parent_id' => $categoryId]);
+
+        Taxonomy::category()->updateDepth();
+
+        DB::table((new Taxonomy())->getTable())
+            ->where('id', $lgaStandardsId)
+            ->delete();
+    }
+}

--- a/database/migrations/2021_06_04_140343_add_lga_standards_top_level_category_taxonomy_to_taxonomies_table.php
+++ b/database/migrations/2021_06_04_140343_add_lga_standards_top_level_category_taxonomy_to_taxonomies_table.php
@@ -10,8 +10,6 @@ class AddLgaStandardsTopLevelCategoryTaxonomyToTaxonomiesTable extends Migration
 {
     /**
      * Run the migrations.
-     *
-     * @return void
      */
     public function up()
     {
@@ -64,8 +62,6 @@ class AddLgaStandardsTopLevelCategoryTaxonomyToTaxonomiesTable extends Migration
 
     /**
      * Reverse the migrations.
-     *
-     * @return void
      */
     public function down()
     {

--- a/tests/Feature/OrganisationsTest.php
+++ b/tests/Feature/OrganisationsTest.php
@@ -704,8 +704,8 @@ class OrganisationsTest extends TestCase
     public function test_organisation_admin_can_update_organisation_taxonomies()
     {
         $organisation = factory(Organisation::class)->create();
-        $taxonomy1 = Taxonomy::category()->children()->firstOrFail()->children->get(0);
-        $taxonomy2 = Taxonomy::category()->children()->firstOrFail()->children->get(1);
+        $taxonomy1 = factory(Taxonomy::class)->create();
+        $taxonomy2 = factory(Taxonomy::class)->create();
         $organisation->syncTaxonomyRelationships(collect([$taxonomy1]));
         $user = factory(User::class)->create()->makeOrganisationAdmin($organisation);
         $payload = [
@@ -750,9 +750,9 @@ class OrganisationsTest extends TestCase
     public function test_global_admin_can_update_organisation_taxonomies()
     {
         $organisation = factory(Organisation::class)->create();
-        $taxonomy1 = Taxonomy::category()->children()->firstOrFail()->children->get(0);
-        $taxonomy2 = Taxonomy::category()->children()->firstOrFail()->children->get(1);
-        $taxonomy3 = Taxonomy::category()->children()->firstOrFail()->children->get(2);
+        $taxonomy1 = factory(Taxonomy::class)->create();
+        $taxonomy2 = factory(Taxonomy::class)->create();
+        $taxonomy3 = factory(Taxonomy::class)->create();
         $organisation->syncTaxonomyRelationships(collect([$taxonomy1]));
 
         $this->assertDatabaseHas(table(OrganisationTaxonomy::class), [

--- a/tests/Feature/ServicesTest.php
+++ b/tests/Feature/ServicesTest.php
@@ -1689,6 +1689,7 @@ class ServicesTest extends TestCase
             ],
             'category_taxonomies' => [
                 $taxonomy->id,
+                $taxonomy->parent_id,
             ],
             'eligibility_types' => [
                 'custom' => [],
@@ -1766,6 +1767,7 @@ class ServicesTest extends TestCase
             ],
             'category_taxonomies' => [
                 $taxonomy->id,
+                $taxonomy->parent_id,
             ],
             'eligibility_types' => [
                 'custom' => [],
@@ -1995,6 +1997,7 @@ class ServicesTest extends TestCase
             ],
             'category_taxonomies' => [
                 $taxonomy->id,
+                $taxonomy->parent_id,
             ],
         ]);
 
@@ -2484,6 +2487,7 @@ class ServicesTest extends TestCase
             'social_medias' => [],
             'category_taxonomies' => [
                 $taxonomy->id,
+                $taxonomy->parent_id,
             ],
         ];
         $response = $this->json('PUT', "/core/v1/services/{$service->id}", $payload);

--- a/tests/Feature/ServicesTest.php
+++ b/tests/Feature/ServicesTest.php
@@ -1029,6 +1029,7 @@ class ServicesTest extends TestCase
     public function test_global_admin_can_create_one_accepting_referrals()
     {
         $organisation = factory(Organisation::class)->create();
+        $taxonomy = factory(Taxonomy::class)->create();
         $user = factory(User::class)->create()->makeGlobalAdmin();
 
         Passport::actingAs($user);
@@ -1086,22 +1087,21 @@ class ServicesTest extends TestCase
                 ],
             ],
             'gallery_items' => [],
-            'category_taxonomies' => [Taxonomy::category()->children()->firstOrFail()->id],
+            'category_taxonomies' => [$taxonomy->id],
         ];
         $response = $this->json('POST', '/core/v1/services', $payload);
 
         $response->assertStatus(Response::HTTP_CREATED);
         $responsePayload = $payload;
-        $responsePayload['category_taxonomies'] = [
-            [
-                'id' => Taxonomy::category()->children()->firstOrFail()->id,
-                'parent_id' => Taxonomy::category()->children()->firstOrFail()->parent_id,
-                'name' => Taxonomy::category()->children()->firstOrFail()->name,
-                'created_at' => Taxonomy::category()->children()->firstOrFail()->created_at->format(CarbonImmutable::ISO8601),
-                'updated_at' => Taxonomy::category()->children()->firstOrFail()->updated_at->format(CarbonImmutable::ISO8601),
-            ],
-        ];
+        unset($responsePayload['category_taxonomies']);
         $response->assertJsonFragment($responsePayload);
+        $response->assertJsonFragment([
+            'id' => $taxonomy->id,
+            'parent_id' => $taxonomy->parent_id,
+            'name' => $taxonomy->name,
+            'created_at' => $taxonomy->created_at->format(CarbonImmutable::ISO8601),
+            'updated_at' => $taxonomy->updated_at->format(CarbonImmutable::ISO8601),
+        ]);
     }
 
     public function test_global_admin_cannot_create_one_with_referral_disclaimer_showing()
@@ -1178,9 +1178,7 @@ class ServicesTest extends TestCase
 
         Passport::actingAs($user);
 
-        $taxonomy = Taxonomy::category()
-            ->children()
-            ->firstOrFail();
+        $taxonomy = factory(Taxonomy::class)->create();
 
         $payload = [
             'organisation_id' => $organisation->id,
@@ -1250,6 +1248,7 @@ class ServicesTest extends TestCase
         $organisation2 = factory(Organisation::class)->create();
         $organisation3 = factory(Organisation::class)->create();
         $organisation4 = factory(Organisation::class)->create();
+        $taxonomy = factory(Taxonomy::class)->create();
         $user = factory(User::class)->create()->makeGlobalAdmin();
 
         //Given that a global admin is logged in
@@ -1308,7 +1307,7 @@ class ServicesTest extends TestCase
                 ],
             ],
             'gallery_items' => [],
-            'category_taxonomies' => [Taxonomy::category()->children()->firstOrFail()->id],
+            'category_taxonomies' => [$taxonomy->id],
         ];
 
         $response = $this->json('POST', '/core/v1/services', $payload);
@@ -1387,6 +1386,7 @@ class ServicesTest extends TestCase
     public function test_guest_can_view_one()
     {
         $service = factory(Service::class)->create();
+        $taxonomy = factory(Taxonomy::class)->create();
         $service->usefulInfos()->create([
             'title' => 'Did You Know?',
             'description' => 'This is a test description',
@@ -1401,7 +1401,7 @@ class ServicesTest extends TestCase
             'url' => 'https://www.instagram.com/ayupdigital/',
         ]);
         $service->serviceTaxonomies()->create([
-            'taxonomy_id' => Taxonomy::category()->children()->first()->id,
+            'taxonomy_id' => $taxonomy->id,
         ]);
 
         $response = $this->json('GET', "/core/v1/services/{$service->id}");
@@ -1463,11 +1463,11 @@ class ServicesTest extends TestCase
             ],
             'category_taxonomies' => [
                 [
-                    'id' => Taxonomy::category()->children()->first()->id,
-                    'parent_id' => Taxonomy::category()->children()->first()->parent_id,
-                    'name' => Taxonomy::category()->children()->first()->name,
-                    'created_at' => Taxonomy::category()->children()->first()->created_at->format(CarbonImmutable::ISO8601),
-                    'updated_at' => Taxonomy::category()->children()->first()->updated_at->format(CarbonImmutable::ISO8601),
+                    'id' => $taxonomy->id,
+                    'parent_id' => $taxonomy->parent_id,
+                    'name' => $taxonomy->name,
+                    'created_at' => $taxonomy->created_at->format(CarbonImmutable::ISO8601),
+                    'updated_at' => $taxonomy->updated_at->format(CarbonImmutable::ISO8601),
                 ],
             ],
             'gallery_items' => [],
@@ -1479,6 +1479,7 @@ class ServicesTest extends TestCase
     public function test_guest_can_view_one_by_slug()
     {
         $service = factory(Service::class)->create();
+        $taxonomy = factory(Taxonomy::class)->create();
         $service->usefulInfos()->create([
             'title' => 'Did You Know?',
             'description' => 'This is a test description',
@@ -1493,7 +1494,7 @@ class ServicesTest extends TestCase
             'url' => 'https://www.instagram.com/ayupdigital/',
         ]);
         $service->serviceTaxonomies()->create([
-            'taxonomy_id' => Taxonomy::category()->children()->first()->id,
+            'taxonomy_id' => $taxonomy->id,
         ]);
 
         $response = $this->json('GET', "/core/v1/services/{$service->slug}");
@@ -1555,11 +1556,11 @@ class ServicesTest extends TestCase
             ],
             'category_taxonomies' => [
                 [
-                    'id' => Taxonomy::category()->children()->first()->id,
-                    'parent_id' => Taxonomy::category()->children()->first()->parent_id,
-                    'name' => Taxonomy::category()->children()->first()->name,
-                    'created_at' => Taxonomy::category()->children()->first()->created_at->format(CarbonImmutable::ISO8601),
-                    'updated_at' => Taxonomy::category()->children()->first()->updated_at->format(CarbonImmutable::ISO8601),
+                    'id' => $taxonomy->id,
+                    'parent_id' => $taxonomy->parent_id,
+                    'name' => $taxonomy->name,
+                    'created_at' => $taxonomy->created_at->format(CarbonImmutable::ISO8601),
+                    'updated_at' => $taxonomy->updated_at->format(CarbonImmutable::ISO8601),
                 ],
             ],
             'gallery_items' => [],
@@ -1587,7 +1588,7 @@ class ServicesTest extends TestCase
             'url' => 'https://www.instagram.com/ayupdigital/',
         ]);
         $service->serviceTaxonomies()->create([
-            'taxonomy_id' => Taxonomy::category()->children()->first()->id,
+            'taxonomy_id' => factory(Taxonomy::class)->create()->id,
         ]);
 
         $this->json('GET', "/core/v1/services/{$service->id}");
@@ -1629,7 +1630,7 @@ class ServicesTest extends TestCase
             'slug' => 'test-service',
             'status' => Service::STATUS_ACTIVE,
         ]);
-        $taxonomy = Taxonomy::category()->children()->firstOrFail();
+        $taxonomy = factory(Taxonomy::class)->create();
         $service->syncTaxonomyRelationships(new Collection([$taxonomy]));
         $user = factory(User::class)->create()->makeServiceAdmin($service);
 
@@ -1706,7 +1707,7 @@ class ServicesTest extends TestCase
             'slug' => 'test-service',
             'status' => Service::STATUS_ACTIVE,
         ]);
-        $taxonomy = Taxonomy::category()->children()->firstOrFail();
+        $taxonomy = factory(Taxonomy::class)->create();
         $service->syncTaxonomyRelationships(new Collection([$taxonomy]));
         $user = factory(User::class)->create()->makeServiceAdmin($service);
 
@@ -1783,7 +1784,7 @@ class ServicesTest extends TestCase
             'slug' => 'test-service',
             'status' => Service::STATUS_ACTIVE,
         ]);
-        $taxonomy = Taxonomy::category()->children()->firstOrFail();
+        $taxonomy = factory(Taxonomy::class)->create();
         $service->syncTaxonomyRelationships(new Collection([$taxonomy]));
         $user = factory(User::class)->create()->makeGlobalAdmin();
 
@@ -1861,7 +1862,7 @@ class ServicesTest extends TestCase
             'slug' => 'test-service',
             'status' => Service::STATUS_ACTIVE,
         ]);
-        $taxonomy = Taxonomy::category()->children()->firstOrFail();
+        $taxonomy = factory(Taxonomy::class)->create();
         $service->syncTaxonomyRelationships(new Collection([$taxonomy]));
         $user = factory(User::class)->create()->makeGlobalAdmin();
 
@@ -1935,7 +1936,7 @@ class ServicesTest extends TestCase
             'slug' => 'test-service',
             'status' => Service::STATUS_ACTIVE,
         ]);
-        $taxonomy = Taxonomy::category()->children()->firstOrFail();
+        $taxonomy = factory(Taxonomy::class)->create();
         $service->syncTaxonomyRelationships(new Collection([$taxonomy]));
         $user = factory(User::class)->create()->makeServiceAdmin($service);
 
@@ -2007,7 +2008,7 @@ class ServicesTest extends TestCase
     public function test_service_admin_cannot_update_taxonomies()
     {
         $service = factory(Service::class)->create();
-        $taxonomy = Taxonomy::category()->children()->firstOrFail();
+        $taxonomy = factory(Taxonomy::class)->create();
         $service->syncTaxonomyRelationships(new Collection([$taxonomy]));
         $user = factory(User::class)->create()->makeServiceAdmin($service);
 
@@ -2081,7 +2082,7 @@ class ServicesTest extends TestCase
     public function test_global_admin_can_update_taxonomies()
     {
         $service = factory(Service::class)->create();
-        $taxonomy = Taxonomy::category()->children()->firstOrFail();
+        $taxonomy = factory(Taxonomy::class)->create();
         $service->syncTaxonomyRelationships(new Collection([$taxonomy]));
         $user = factory(User::class)->create()->makeGlobalAdmin();
 
@@ -2158,7 +2159,7 @@ class ServicesTest extends TestCase
             'slug' => 'test-service',
             'status' => Service::STATUS_ACTIVE,
         ]);
-        $taxonomy = Taxonomy::category()->children()->firstOrFail();
+        $taxonomy = factory(Taxonomy::class)->create();
         $service->syncTaxonomyRelationships(new Collection([$taxonomy]));
         $user = factory(User::class)->create()->makeServiceAdmin($service);
 
@@ -2214,7 +2215,7 @@ class ServicesTest extends TestCase
             'slug' => 'test-service',
             'status' => Service::STATUS_ACTIVE,
         ]);
-        $taxonomy = Taxonomy::category()->children()->firstOrFail();
+        $taxonomy = factory(Taxonomy::class)->create();
         $service->syncTaxonomyRelationships(new Collection([$taxonomy]));
         $user = factory(User::class)->create()->makeServiceAdmin($service);
 
@@ -2270,7 +2271,7 @@ class ServicesTest extends TestCase
             'slug' => 'test-service',
             'status' => Service::STATUS_ACTIVE,
         ]);
-        $taxonomy = Taxonomy::category()->children()->firstOrFail();
+        $taxonomy = factory(Taxonomy::class)->create();
         $service->syncTaxonomyRelationships(new Collection([$taxonomy]));
         $user = factory(User::class)->create()->makeGlobalAdmin();
 
@@ -2326,7 +2327,7 @@ class ServicesTest extends TestCase
             'slug' => 'test-service',
             'status' => Service::STATUS_ACTIVE,
         ]);
-        $taxonomy = Taxonomy::category()->children()->firstOrFail();
+        $taxonomy = factory(Taxonomy::class)->create();
         $service->syncTaxonomyRelationships(new Collection([$taxonomy]));
         $user = factory(User::class)->create()->makeGlobalAdmin();
 
@@ -2382,7 +2383,7 @@ class ServicesTest extends TestCase
             'slug' => 'test-service',
             'status' => Service::STATUS_ACTIVE,
         ]);
-        $taxonomy = Taxonomy::category()->children()->firstOrFail();
+        $taxonomy = factory(Taxonomy::class)->create();
         $service->syncTaxonomyRelationships(new Collection([$taxonomy]));
         $user = factory(User::class)->create()->makeGlobalAdmin();
 
@@ -2440,7 +2441,7 @@ class ServicesTest extends TestCase
             'status' => Service::STATUS_ACTIVE,
             'referral_method' => Service::REFERRAL_METHOD_INTERNAL,
         ]);
-        $taxonomy = Taxonomy::category()->children()->firstOrFail();
+        $taxonomy = factory(Taxonomy::class)->create();
         $service->syncTaxonomyRelationships(new Collection([$taxonomy]));
         $user = factory(User::class)->create()->makeServiceAdmin($service);
 
@@ -2500,7 +2501,7 @@ class ServicesTest extends TestCase
             'referral_method' => Service::REFERRAL_METHOD_INTERNAL,
             'referral_email' => $this->faker->safeEmail,
         ]);
-        $taxonomy = Taxonomy::category()->children()->firstOrFail();
+        $taxonomy = factory(Taxonomy::class)->create();
         $service->syncTaxonomyRelationships(new Collection([$taxonomy]));
         $user = factory(User::class)->create()->makeGlobalAdmin();
 
@@ -2558,7 +2559,7 @@ class ServicesTest extends TestCase
             'referral_method' => Service::REFERRAL_METHOD_INTERNAL,
             'referral_email' => $this->faker->safeEmail,
         ]);
-        $taxonomy = Taxonomy::category()->children()->firstOrFail();
+        $taxonomy = factory(Taxonomy::class)->create();
         $service->syncTaxonomyRelationships(new Collection([$taxonomy]));
         $user = factory(User::class)->create()->makeGlobalAdmin();
         $image = Storage::disk('local')->get('/test-data/image.png');
@@ -2588,7 +2589,7 @@ class ServicesTest extends TestCase
             'slug' => 'test-service',
             'status' => Service::STATUS_ACTIVE,
         ]);
-        $taxonomy = Taxonomy::category()->children()->firstOrFail();
+        $taxonomy = factory(Taxonomy::class)->create();
         $service->syncTaxonomyRelationships(new Collection([$taxonomy]));
         $user = factory(User::class)->create()->makeGlobalAdmin();
 
@@ -2609,7 +2610,7 @@ class ServicesTest extends TestCase
             'slug' => 'test-service',
             'status' => Service::STATUS_ACTIVE,
         ]);
-        $taxonomy = Taxonomy::category()->children()->firstOrFail();
+        $taxonomy = factory(Taxonomy::class)->create();
         $service->syncTaxonomyRelationships(new Collection([$taxonomy]));
         $user = factory(User::class)->create()->makeServiceAdmin($service);
 
@@ -2664,7 +2665,7 @@ class ServicesTest extends TestCase
             'referral_method' => Service::REFERRAL_METHOD_EXTERNAL,
             'referral_url' => $this->faker->url,
         ]);
-        $taxonomy = Taxonomy::category()->children()->firstOrFail();
+        $taxonomy = factory(Taxonomy::class)->create();
         $service->syncTaxonomyRelationships(new Collection([$taxonomy]));
         $user = factory(User::class)->create()->makeGlobalAdmin();
 
@@ -2683,7 +2684,7 @@ class ServicesTest extends TestCase
             'slug' => 'test-service',
             'status' => Service::STATUS_ACTIVE,
         ]);
-        $taxonomy = Taxonomy::category()->children()->firstOrFail();
+        $taxonomy = factory(Taxonomy::class)->create();
         $service->syncTaxonomyRelationships(new Collection([$taxonomy]));
         $user = factory(User::class)->create()->makeOrganisationAdmin($service->organisation);
 
@@ -2702,7 +2703,7 @@ class ServicesTest extends TestCase
             'slug' => 'test-service',
             'status' => Service::STATUS_ACTIVE,
         ]);
-        $taxonomy = Taxonomy::category()->children()->firstOrFail();
+        $taxonomy = factory(Taxonomy::class)->create();
         $service->syncTaxonomyRelationships(new Collection([$taxonomy]));
         $user = factory(User::class)->create()->makeGlobalAdmin();
 
@@ -2723,7 +2724,7 @@ class ServicesTest extends TestCase
             'slug' => 'test-service',
             'status' => Service::STATUS_ACTIVE,
         ]);
-        $taxonomy = Taxonomy::category()->children()->firstOrFail();
+        $taxonomy = factory(Taxonomy::class)->create();
         $service->syncTaxonomyRelationships(new Collection([$taxonomy]));
         $user = factory(User::class)->create()->makeGlobalAdmin();
 
@@ -2748,7 +2749,7 @@ class ServicesTest extends TestCase
             'slug' => 'test-service',
             'status' => Service::STATUS_ACTIVE,
         ]);
-        $taxonomy = Taxonomy::category()->children()->firstOrFail();
+        $taxonomy = factory(Taxonomy::class)->create();
         $service->syncTaxonomyRelationships(new Collection([$taxonomy]));
         $user = factory(User::class)->create()->makeGlobalAdmin();
 
@@ -2937,9 +2938,9 @@ class ServicesTest extends TestCase
 
     public function test_guest_can_list_related()
     {
-        $taxonomyOne = Taxonomy::category()->children()->first()->children()->skip(0)->take(1)->first();
-        $taxonomyTwo = Taxonomy::category()->children()->first()->children()->skip(1)->take(1)->first();
-        $taxonomyThree = Taxonomy::category()->children()->first()->children()->skip(2)->take(1)->first();
+        $taxonomyOne = factory(Taxonomy::class)->create();
+        $taxonomyTwo = factory(Taxonomy::class)->create();
+        $taxonomyThree = factory(Taxonomy::class)->create();
 
         $service = factory(Service::class)->create();
         $service->serviceTaxonomies()->create(['taxonomy_id' => $taxonomyOne->id]);
@@ -3086,17 +3087,18 @@ class ServicesTest extends TestCase
     public function test_related_services_order_by_taxonomy_depth()
     {
         // Create taxonomies.
-        $taxonomyOneDepthOne = Taxonomy::category()->children()->create([
+        $taxonomy = factory(Taxonomy::class)->create();
+        $taxonomyOneDepthOne = $taxonomy->children()->create([
             'name' => 'Taxonomy One',
             'order' => 1,
             'depth' => 1,
         ]);
-        $taxonomyTwoDepthOne = Taxonomy::category()->children()->create([
+        $taxonomyTwoDepthOne = $taxonomy->children()->create([
             'name' => 'Taxonomy Two',
             'order' => 1,
             'depth' => 1,
         ]);
-        $taxonomyThreeDepthOne = Taxonomy::category()->children()->create([
+        $taxonomyThreeDepthOne = $taxonomy->children()->create([
             'name' => 'Taxonomy Three',
             'order' => 1,
             'depth' => 1,
@@ -4441,7 +4443,6 @@ class ServicesTest extends TestCase
 
         $taxonomyIds = $service->serviceEligibilities()->pluck('taxonomy_id')->all();
 
-
         $response = $this->get(route('core.v1.services.show', $service->id));
 
         $response->assertJsonFragment([
@@ -4473,9 +4474,7 @@ class ServicesTest extends TestCase
             )
             ->create();
 
-
         $taxonomyIds = $service->serviceEligibilities()->pluck('taxonomy_id')->all();
-
 
         $response = $this->get(route('core.v1.services.show', $service->id));
 
@@ -4796,7 +4795,7 @@ class ServicesTest extends TestCase
                 ->first()
                 ->id;
         })
-        ->toArray();
+            ->toArray();
 
         sort($taxonomyIds, SORT_STRING);
 
@@ -4814,7 +4813,7 @@ class ServicesTest extends TestCase
 
         $service->load('serviceEligibilities');
 
-        foreach($service->serviceEligibilities['taxonomies'] as $taxonomyId) {
+        foreach ($service->serviceEligibilities['taxonomies'] as $taxonomyId) {
             $this->assertTrue(in_array($taxonomyId, $taxonomyIds));
         }
     }
@@ -4849,7 +4848,6 @@ class ServicesTest extends TestCase
             ],
         ];
 
-
         $response = $this->json('PUT', "/core/v1/services/{$service->id}", $payload);
         $response->assertStatus(Response::HTTP_OK);
         $response->assertJsonFragment($payload);
@@ -4883,7 +4881,7 @@ class ServicesTest extends TestCase
                 ->first()
                 ->id;
         })
-        ->toArray();
+            ->toArray();
 
         sort($taxonomyIds, SORT_STRING);
 
@@ -4911,7 +4909,7 @@ class ServicesTest extends TestCase
         $service = $service->fresh();
         $service->load('serviceEligibilities');
 
-        foreach($service->serviceEligibilities['taxonomies'] as $taxonomyId) {
+        foreach ($service->serviceEligibilities['taxonomies'] as $taxonomyId) {
             $this->assertTrue(in_array($taxonomyId, $taxonomyIds));
         }
 
@@ -4933,7 +4931,6 @@ class ServicesTest extends TestCase
                 'withCategoryTaxonomies'
             )
             ->create();
-
 
         Passport::actingAs($user);
 

--- a/tests/Feature/TaxonomyCategoriesTest.php
+++ b/tests/Feature/TaxonomyCategoriesTest.php
@@ -138,9 +138,9 @@ class TaxonomyCategoriesTest extends TestCase
     public function test_order_is_updated_when_created_at_beginning()
     {
         $user = factory(User::class)->create()->makeSuperAdmin();
-        $topLevelCategories = Taxonomy::category()->children()->orderBy('order')->get();
+        $topLevelCategories = Taxonomy::category()->children()->first()->children()->orderBy('order')->get();
         $payload = [
-            'parent_id' => null,
+            'parent_id' => $topLevelCategories->first()->parent_id,
             'name' => 'PHPUnit Taxonomy Category Test',
             'order' => 1,
         ];
@@ -159,9 +159,9 @@ class TaxonomyCategoriesTest extends TestCase
     public function test_order_is_updated_when_created_at_middle()
     {
         $user = factory(User::class)->create()->makeSuperAdmin();
-        $topLevelCategories = Taxonomy::category()->children()->orderBy('order')->get();
+        $topLevelCategories = Taxonomy::category()->children()->first()->children()->orderBy('order')->get();
         $payload = [
-            'parent_id' => null,
+            'parent_id' => $topLevelCategories->first()->parent_id,
             'name' => 'PHPUnit Taxonomy Category Test',
             'order' => 2,
         ];
@@ -185,9 +185,9 @@ class TaxonomyCategoriesTest extends TestCase
     public function test_order_is_updated_when_created_at_end()
     {
         $user = factory(User::class)->create()->makeSuperAdmin();
-        $topLevelCategories = Taxonomy::category()->children()->orderBy('order')->get();
+        $topLevelCategories = Taxonomy::category()->children()->first()->children()->orderBy('order')->get();
         $payload = [
-            'parent_id' => null,
+            'parent_id' => $topLevelCategories->first()->parent_id,
             'name' => 'PHPUnit Taxonomy Category Test',
             'order' => $topLevelCategories->count() + 1,
         ];


### PR DESCRIPTION
### Summary

https://app.clubhouse.io/ayup-digital-ltd/story/288/nest-new-taxonomies-under-lga-top-level-taxonomy

- Created migration to add new top level Category taxonomy (i.e. child of Categories taxonomy) 'LGA Standards'.
- Resolved failing tests that occurred due to the change in taxonomy structure

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [ ] The code has been linted `./develop composer fix:style`

### Release checklist

Run migration

### Notes

NA
