### PR TITLE
Feature/hounslow ch181 fix social medias validation message

### DIFF
--- a/app/Http/Requests/Service/StoreRequest.php
+++ b/app/Http/Requests/Service/StoreRequest.php
@@ -254,7 +254,6 @@ class StoreRequest extends FormRequest
             'contact_email.email' => "Additional Info tab -  Please enter an email address users can use to contact your {$type} (eg. name@example.com).",
             'useful_infos.*.title.required_with' => 'Good to know tab - Please select a title.',
             'useful_infos.*.description.required_with' => 'Good to know tab - Please enter a description.',
-            'social_medias' => 'This field is no longer accepted for services and should be set in the Organisation.',
         ];
     }
 

--- a/app/Http/Requests/Service/UpdateRequest.php
+++ b/app/Http/Requests/Service/UpdateRequest.php
@@ -363,7 +363,6 @@ class UpdateRequest extends FormRequest
             'contact_email.email' => "Additional Info tab -  Please enter an email address users can use to contact your {$type} (eg. name@example.com).",
             'useful_infos.*.title.required_with' => 'Good to know tab - Please select a title.',
             'useful_infos.*.description.required_with' => 'Good to know tab - Please enter a description.',
-            'social_medias' => 'This field is no longer accepted for services and should be set in the Organisation.',
         ];
     }
 }

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -125,8 +125,8 @@ return [
     */
 
     'custom' => [
-        'attribute-name' => [
-            'rule-name' => 'custom-message',
+        'social_medias' => [
+            'size' => 'This field is no longer accepted for services and should be set in the Organisation.',
         ],
     ],
 
@@ -134,8 +134,7 @@ return [
     |--------------------------------------------------------------------------
     | Custom Validation Attributes
     |--------------------------------------------------------------------------
-    |
-    | The following language lines are used to swap attribute place-holders
+    |    | The following language lines are used to swap attribute place-holders
     | with something more reader friendly such as E-Mail Address instead
     | of "email". This simply helps us make messages a little cleaner.
     |

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -134,7 +134,8 @@ return [
     |--------------------------------------------------------------------------
     | Custom Validation Attributes
     |--------------------------------------------------------------------------
-    |    | The following language lines are used to swap attribute place-holders
+    |
+    | The following language lines are used to swap attribute place-holders
     | with something more reader friendly such as E-Mail Address instead
     | of "email". This simply helps us make messages a little cleaner.
     |

--- a/tests/Feature/ServicesTest.php
+++ b/tests/Feature/ServicesTest.php
@@ -4531,6 +4531,7 @@ class ServicesTest extends TestCase
         // Create the update request as service admin
         $response = $this->json('PUT', "/core/v1/services/{$service->id}", $payload);
         $response->assertStatus(422);
+        $response->assertJsonFragment(['social_medias' => ['This field is no longer accepted for services and should be set in the Organisation.']]);
     }
 
     public function test_service_creation_rejected_if_social_medias_field_is_populated()
@@ -4588,6 +4589,8 @@ class ServicesTest extends TestCase
         $response = $this->json('POST', '/core/v1/services', $payload);
 
         $response->assertStatus(422);
+        $response->assertJsonFragment(['social_medias' => ['This field is no longer accepted for services and should be set in the Organisation.']]);
+
     }
 
     public function test_service_update_request_approval_rejected_if_social_medias_field_is_populated()
@@ -4640,5 +4643,7 @@ class ServicesTest extends TestCase
         $response = $this->json('PUT', "/core/v1/update-requests/{$updateRequest->id}/approve");
 
         $response->assertStatus(422);
+        $response->assertJsonFragment(['social_medias' => ['This field is no longer accepted for services and should be set in the Organisation.']]);
+
     }
 }


### PR DESCRIPTION
### Summary

Feedback from @AyupMike on CH-181: https://app.clubhouse.io/ayup-digital-ltd/story/181/remove-social-media-support-for-services#activity-579

The validation message is now correct, and returned from the `resources/lang/en/validation.php` file

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`
