### PR TITLE
Restricted category children taxonomies to move

### DIFF
--- a/database/migrations/2021_06_04_140343_add_lga_standards_top_level_category_taxonomy_to_taxonomies_table.php
+++ b/database/migrations/2021_06_04_140343_add_lga_standards_top_level_category_taxonomy_to_taxonomies_table.php
@@ -33,7 +33,7 @@ class AddLgaStandardsTopLevelCategoryTaxonomyToTaxonomiesTable extends Migration
         // Move all direct children of Category to LGA Standards
         DB::table((new Taxonomy())->getTable())
             ->where('parent_id', $categoryId)
-            ->where('id', '<>', $lgaStandardsId)
+            ->whereIn('name', ['Functions', 'Services'])
             ->update(['parent_id' => $lgaStandardsId]);
 
         Taxonomy::category()->updateDepth();


### PR DESCRIPTION
### Summary

https://app.clubhouse.io/ayup-digital-ltd/story/288/nest-new-taxonomies-under-lga-top-level-taxonomy

Updated the migration to make the Category child taxonomies to move under the new LGA Standards taxonomy more specific. It will now only move the Functions and Services child taxonomies. This also prevents any issues with the new OpenActive Category child taxonomy.

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

NA

### Notes

NA
