### PR TITLE
Delete all service eligibilities prior to service delete

### DIFF
--- a/app/Http/Controllers/Core/V1/ServiceController.php
+++ b/app/Http/Controllers/Core/V1/ServiceController.php
@@ -161,6 +161,8 @@ class ServiceController extends Controller
         return DB::transaction(function () use ($request, $service) {
             event(EndpointHit::onDelete($request, "Deleted service [{$service->id}]", $service));
 
+            $service->serviceEligibilities()->delete();
+
             $service->delete();
 
             return new ResourceDeleted('service');

--- a/tests/Feature/ServicesTest.php
+++ b/tests/Feature/ServicesTest.php
@@ -2463,6 +2463,22 @@ class ServicesTest extends TestCase
         $this->assertDatabaseMissing((new Service())->getTable(), ['id' => $service->id]);
     }
 
+    public function test_service_can_be_deleted_when_disabled()
+    {
+        $service = factory(Service::class)->create([
+            'status' => Service::STATUS_INACTIVE
+        ]);
+
+        $user = factory(User::class)->create()->makeSuperAdmin();
+
+        Passport::actingAs($user);
+
+        $response = $this->json('DELETE', "/core/v1/services/{$service->id}");
+
+        $response->assertStatus(Response::HTTP_OK);
+        $this->assertDatabaseMissing((new Service())->getTable(), ['id' => $service->id]);
+    }
+
     /*
      * Refresh service.
      */


### PR DESCRIPTION
### Summary

https://app.clubhouse.io/ayup-digital-ltd/story/295/deleting-a-service-return-an-500-server-error-message

Service eligibility relationships were preventing services being deleted.

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

NA

### Notes

NA
