### PR TITLE
Bugfix/hounslow ch605 search taxonomy filters changes search behaviour

### DIFF
--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -127,7 +127,10 @@ class Service extends Model implements AppliesUpdateRequests, Notifiable, HasTax
                 ],
             ],
             'service_eligibilities' => [
-                'type' => 'keyword',
+                'type' => 'text',
+                'fields' => [
+                    'keyword' => ['type' => 'keyword'],
+                ],
             ],
         ],
     ];
@@ -139,6 +142,15 @@ class Service extends Model implements AppliesUpdateRequests, Notifiable, HasTax
      */
     public function toSearchableArray()
     {
+        $serviceEligibilities = $this->eligibilities;
+        $serviceEligibilityIds = $serviceEligibilities->pluck('taxonomies.id')->toArray();
+        $serviceEligibilityNames = $serviceEligibilities->pluck('taxonomies.name')->toArray();
+        $serviceEligibilityRoot = Taxonomy::serviceEligibility();
+        foreach ($serviceEligibilityRoot->children as $serviceEligibilityType) {
+            if (!$serviceEligibilityType->filterDescendants($serviceEligibilityIds)) {
+                $serviceEligibilityNames[] = $serviceEligibilityType->name . ' All';
+            }
+        }
         return [
             'id' => $this->id,
             'name' => $this->name,
@@ -163,7 +175,7 @@ class Service extends Model implements AppliesUpdateRequests, Notifiable, HasTax
                         ],
                     ];
                 })->toArray(),
-            'service_eligibilities' => $this->eligibilities()->pluck('name')->toArray(),
+            'service_eligibilities' => $serviceEligibilityNames,
         ];
     }
 

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -143,14 +143,15 @@ class Service extends Model implements AppliesUpdateRequests, Notifiable, HasTax
     public function toSearchableArray()
     {
         $serviceEligibilities = $this->eligibilities;
-        $serviceEligibilityIds = $serviceEligibilities->pluck('taxonomies.id')->toArray();
-        $serviceEligibilityNames = $serviceEligibilities->pluck('taxonomies.name')->toArray();
+        $serviceEligibilityIds = $serviceEligibilities->pluck('id')->toArray();
+        $serviceEligibilityNames = $serviceEligibilities->pluck('name')->toArray();
         $serviceEligibilityRoot = Taxonomy::serviceEligibility();
         foreach ($serviceEligibilityRoot->children as $serviceEligibilityType) {
             if (!$serviceEligibilityType->filterDescendants($serviceEligibilityIds)) {
                 $serviceEligibilityNames[] = $serviceEligibilityType->name . ' All';
             }
         }
+
         return [
             'id' => $this->id,
             'name' => $this->name,

--- a/app/Models/Taxonomy.php
+++ b/app/Models/Taxonomy.php
@@ -101,25 +101,45 @@ class Taxonomy extends Model
     }
 
     /**
-     * Return an array of all Taxonomies below the Service Eligibility root.
+     * Return an array of all Taxonomies below the provided Taxonomy root.
      *
      * @param App\Models\Taxonomy $taxonomy
      * @param mixed $allTaxonomies
      * @return Illuminate\Support\Collection
      */
-    public function getAllServiceEligibilities($taxonomy = null, &$allTaxonomies = [])
+    public function getAllDescendantTaxonomies(self $taxonomy, &$allTaxonomies = [])
     {
         if (!$taxonomy) {
             $taxonomy = self::serviceEligibility();
+        }
+
+        if (is_array($allTaxonomies)) {
             $allTaxonomies = collect($allTaxonomies);
         }
 
         $allTaxonomies = $allTaxonomies->merge($taxonomy->children);
 
         foreach ($taxonomy->children as $childTaxonomy) {
-            $this->getAllServiceEligibilities($childTaxonomy, $allTaxonomies);
+            $this->getAllDescendantTaxonomies($childTaxonomy, $allTaxonomies);
         }
 
         return $allTaxonomies;
+    }
+
+    /**
+     * Filter the passed taxonomy IDs for descendants of this taxonomy
+     *
+     * @param Array $taxonomyIds
+     * @return Array|Boolean
+     **/
+    public function filterDescendants(array $taxonomyIds)
+    {
+        $descendantTaxonomyIds = $this
+            ->getAllDescendantTaxonomies($this)
+            ->pluck('id')
+            ->toArray();
+        $taxonomyIds = array_intersect($descendantTaxonomyIds, $taxonomyIds);
+
+        return count($taxonomyIds) ? $taxonomyIds : false;
     }
 }

--- a/app/Models/Taxonomy.php
+++ b/app/Models/Taxonomy.php
@@ -127,11 +127,11 @@ class Taxonomy extends Model
     }
 
     /**
-     * Filter the passed taxonomy IDs for descendants of this taxonomy
+     * Filter the passed taxonomy IDs for descendants of this taxonomy.
      *
-     * @param Array $taxonomyIds
-     * @return Array|Boolean
-     **/
+     * @param array $taxonomyIds
+     * @return array|bool
+     */
     public function filterDescendants(array $taxonomyIds)
     {
         $descendantTaxonomyIds = $this


### PR DESCRIPTION
### Summary

https://app.clubhouse.io/ayup-digital-ltd/story/605/search-taxonomy-filters-changes-search-behaviour

- Added service_eligibility "* All" pseudo taxonomy to all Services without a service eligibility type restriction
- Added filter to Elasticsearch to limit results to selected service eligibilities *or* the pseudo "* All" when a service eligibility type is populated (e.g. Age Range)
- Added selected service eligibilities to should query with default rank boost (1.0)
- Added pseudo eligibility for the eligibility type to the should query with a lower (0.2) boost to include them in the result set but at a lower rank

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

- [ ] Run `ck:reindex-elasticsearch`

### Notes

NA
