### PR TITLE
Feature/hounslow ch517 endpoints to update eligibility taxonomies

### DIFF
--- a/app/Docs/OpenApi.php
+++ b/app/Docs/OpenApi.php
@@ -86,6 +86,7 @@ class OpenApi extends BaseOpenApi implements Responsable
                 Paths\Taxonomies\Organisations\TaxonomyOrganisationsIndexPath::create(),
                 Paths\Taxonomies\Organisations\TaxonomyOrganisationsNestedPath::create(),
                 Paths\Taxonomies\ServiceEligibilities\TaxonomyServiceEligibilitiesRootPath::create(),
+                Paths\Taxonomies\ServiceEligibilities\TaxonomyServiceEligibilitiesNestedPath::create(),
                 Paths\Thesaurus\ThesaurusRootPath::create(),
                 Paths\UpdateRequests\UpdateRequestsRootPath::create(),
                 Paths\UpdateRequests\UpdateRequestsIndexPath::create(),

--- a/app/Docs/Operations/Taxonomies/ServiceEligibilities/DestroyTaxonomyServiceEligibilityOperation.php
+++ b/app/Docs/Operations/Taxonomies/ServiceEligibilities/DestroyTaxonomyServiceEligibilityOperation.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Docs\Operations\Taxonomies\ServiceEligibilities;
+
+use App\Docs\Responses\ResourceDeletedResponse;
+use App\Docs\Tags\TaxonomyServiceEligibilitiesTag;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\BaseObject;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Operation;
+
+class DestroyTaxonomyServiceEligibilityOperation extends Operation
+{
+    /**
+     * @param string|null $objectId
+     * @throws \GoldSpecDigital\ObjectOrientedOAS\Exceptions\InvalidArgumentException
+     * @return static
+     */
+    public static function create(string $objectId = null): BaseObject
+    {
+        return parent::create($objectId)
+            ->action(static::ACTION_DELETE)
+            ->tags(TaxonomyServiceEligibilitiesTag::create())
+            ->summary('Delete a specific service eligibility taxonomy')
+            ->description('**Permission:** `Global Admin`')
+            ->responses(
+                ResourceDeletedResponse::create(null, 'taxonomy service eligibility')
+            );
+    }
+}

--- a/app/Docs/Operations/Taxonomies/ServiceEligibilities/ShowTaxonomyServiceEligibilityOperation.php
+++ b/app/Docs/Operations/Taxonomies/ServiceEligibilities/ShowTaxonomyServiceEligibilityOperation.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Docs\Operations\Taxonomies\ServiceEligibilities;
+
+use App\Docs\Schemas\ResourceSchema;
+use App\Docs\Schemas\Taxonomy\ServiceEligibility\TaxonomyServiceEligibilitySchema;
+use App\Docs\Tags\TaxonomyServiceEligibilitiesTag;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\BaseObject;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\MediaType;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Operation;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Response;
+
+class ShowTaxonomyServiceEligibilityOperation extends Operation
+{
+    /**
+     * @param string|null $objectId
+     * @throws \GoldSpecDigital\ObjectOrientedOAS\Exceptions\InvalidArgumentException
+     * @return static
+     */
+    public static function create(string $objectId = null): BaseObject
+    {
+        return parent::create($objectId)
+            ->action(static::ACTION_GET)
+            ->tags(TaxonomyServiceEligibilitiesTag::create())
+            ->summary('Get a specific service eligibility taxonomy')
+            ->description('**Permission:** `Open`')
+            ->noSecurity()
+            ->responses(
+                Response::ok()->content(
+                    MediaType::json()->schema(
+                        ResourceSchema::create(null, TaxonomyServiceEligibilitySchema::create())
+                    )
+                )
+            );
+    }
+}

--- a/app/Docs/Operations/Taxonomies/ServiceEligibilities/StoreTaxonomyServiceEligibilityOperation.php
+++ b/app/Docs/Operations/Taxonomies/ServiceEligibilities/StoreTaxonomyServiceEligibilityOperation.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Docs\Operations\Taxonomies\ServiceEligibilities;
+
+use App\Docs\Schemas\ResourceSchema;
+use App\Docs\Schemas\Taxonomy\ServiceEligibility\StoreTaxonomyServiceEligibilitySchema;
+use App\Docs\Schemas\Taxonomy\ServiceEligibility\TaxonomyServiceEligibilitySchema;
+use App\Docs\Tags\TaxonomyServiceEligibilitiesTag;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\BaseObject;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\MediaType;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Operation;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\RequestBody;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Response;
+
+class StoreTaxonomyServiceEligibilityOperation extends Operation
+{
+    /**
+     * @param string|null $objectId
+     * @throws \GoldSpecDigital\ObjectOrientedOAS\Exceptions\InvalidArgumentException
+     * @return static
+     */
+    public static function create(string $objectId = null): BaseObject
+    {
+        return parent::create($objectId)
+            ->action(static::ACTION_POST)
+            ->tags(TaxonomyServiceEligibilitiesTag::create())
+            ->summary('Create a service eligibility taxonomy')
+            ->description('**Permission:** `Global Admin`')
+            ->requestBody(
+                RequestBody::create()
+                    ->required()
+                    ->content(
+                        MediaType::json()->schema(StoreTaxonomyServiceEligibilitySchema::create())
+                    )
+            )
+            ->responses(
+                Response::created()->content(
+                    MediaType::json()->schema(
+                        ResourceSchema::create(null, TaxonomyServiceEligibilitySchema::create())
+                    )
+                )
+            );
+    }
+}

--- a/app/Docs/Operations/Taxonomies/ServiceEligibilities/UpdateTaxonomyServiceEligibilityOperation.php
+++ b/app/Docs/Operations/Taxonomies/ServiceEligibilities/UpdateTaxonomyServiceEligibilityOperation.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Docs\Operations\Taxonomies\ServiceEligibilities;
+
+use App\Docs\Schemas\ResourceSchema;
+use App\Docs\Schemas\Taxonomy\ServiceEligibility\TaxonomyServiceEligibilitySchema;
+use App\Docs\Schemas\Taxonomy\ServiceEligibility\UpdateTaxonomyServiceEligibilitySchema;
+use App\Docs\Tags\TaxonomyServiceEligibilitiesTag;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\BaseObject;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\MediaType;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Operation;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\RequestBody;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Response;
+
+class UpdateTaxonomyServiceEligibilityOperation extends Operation
+{
+    /**
+     * @param string|null $objectId
+     * @throws \GoldSpecDigital\ObjectOrientedOAS\Exceptions\InvalidArgumentException
+     * @return static
+     */
+    public static function create(string $objectId = null): BaseObject
+    {
+        return parent::create($objectId)
+            ->action(static::ACTION_PUT)
+            ->tags(TaxonomyServiceEligibilitiesTag::create())
+            ->summary('Update a specific service eligibility taxonomy')
+            ->description('**Permission:** `Global Admin`')
+            ->requestBody(
+                RequestBody::create()
+                    ->required()
+                    ->content(
+                        MediaType::json()->schema(UpdateTaxonomyServiceEligibilitySchema::create())
+                    )
+            )
+            ->responses(
+                Response::ok()->content(
+                    MediaType::json()->schema(
+                        ResourceSchema::create(null, TaxonomyServiceEligibilitySchema::create())
+                    )
+                )
+            );
+    }
+}

--- a/app/Docs/Paths/Taxonomies/ServiceEligibilities/TaxonomyServiceEligibilitiesNestedPath.php
+++ b/app/Docs/Paths/Taxonomies/ServiceEligibilities/TaxonomyServiceEligibilitiesNestedPath.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Docs\Paths\Taxonomies\ServiceEligibilities;
+
+use App\Docs\Operations\Taxonomies\ServiceEligibilities\DestroyTaxonomyServiceEligibilityOperation;
+use App\Docs\Operations\Taxonomies\ServiceEligibilities\ShowTaxonomyServiceEligibilityOperation;
+use App\Docs\Operations\Taxonomies\ServiceEligibilities\UpdateTaxonomyServiceEligibilityOperation;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\BaseObject;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Parameter;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\PathItem;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Schema;
+
+class TaxonomyServiceEligibilitiesNestedPath extends PathItem
+{
+    /**
+     * @param string|null $objectId
+     * @throws \GoldSpecDigital\ObjectOrientedOAS\Exceptions\InvalidArgumentException
+     * @return static
+     */
+    public static function create(string $objectId = null): BaseObject
+    {
+        return parent::create($objectId)
+            ->route('/taxonomies/service-eligibilities/{eligibility}')
+            ->parameters(
+                Parameter::path()
+                    ->name('eligibility')
+                    ->description('The ID of the eligibility taxonomy')
+                    ->required()
+                    ->schema(Schema::string()->format(Schema::FORMAT_UUID))
+            )
+            ->operations(
+                ShowTaxonomyServiceEligibilityOperation::create(),
+                UpdateTaxonomyServiceEligibilityOperation::create(),
+                DestroyTaxonomyServiceEligibilityOperation::create()
+            );
+    }
+}

--- a/app/Docs/Paths/Taxonomies/ServiceEligibilities/TaxonomyServiceEligibilitiesRootPath.php
+++ b/app/Docs/Paths/Taxonomies/ServiceEligibilities/TaxonomyServiceEligibilitiesRootPath.php
@@ -3,6 +3,7 @@
 namespace App\Docs\Paths\Taxonomies\ServiceEligibilities;
 
 use App\Docs\Operations\Taxonomies\ServiceEligibilities\IndexTaxonomyServiceEligibilityOperation;
+use App\Docs\Operations\Taxonomies\ServiceEligibilities\StoreTaxonomyServiceEligibilityOperation;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\BaseObject;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\PathItem;
 
@@ -18,7 +19,8 @@ class TaxonomyServiceEligibilitiesRootPath extends PathItem
         return parent::create($objectId)
             ->route('/taxonomies/service-eligibilities')
             ->operations(
-                IndexTaxonomyServiceEligibilityOperation::create()
+                IndexTaxonomyServiceEligibilityOperation::create(),
+                StoreTaxonomyServiceEligibilityOperation::create()
             );
     }
 }

--- a/app/Docs/Schemas/Taxonomy/ServiceEligibility/StoreTaxonomyServiceEligibilitySchema.php
+++ b/app/Docs/Schemas/Taxonomy/ServiceEligibility/StoreTaxonomyServiceEligibilitySchema.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Docs\Schemas\Taxonomy\ServiceEligibility;
+
+class StoreTaxonomyServiceEligibilitySchema extends UpdateTaxonomyServiceEligibilitySchema
+{
+    //
+}

--- a/app/Docs/Schemas/Taxonomy/ServiceEligibility/UpdateTaxonomyServiceEligibilitySchema.php
+++ b/app/Docs/Schemas/Taxonomy/ServiceEligibility/UpdateTaxonomyServiceEligibilitySchema.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Docs\Schemas\Taxonomy\ServiceEligibility;
+
+use GoldSpecDigital\ObjectOrientedOAS\Objects\BaseObject;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Schema;
+
+class UpdateTaxonomyServiceEligibilitySchema extends Schema
+{
+    /**
+     * @param string|null $objectId
+     * @throws \GoldSpecDigital\ObjectOrientedOAS\Exceptions\InvalidArgumentException
+     * @return static
+     */
+    public static function create(string $objectId = null): BaseObject
+    {
+        return parent::create($objectId)
+            ->type(static::TYPE_OBJECT)
+            ->required('parent_id', 'name', 'order')
+            ->properties(
+                Schema::string('parent_id')
+                    ->format(Schema::FORMAT_UUID)
+                    ->nullable(),
+                Schema::string('name'),
+                Schema::integer('order')
+            );
+    }
+}

--- a/app/Http/Controllers/Core/V1/TaxonomyServiceEligibilityController.php
+++ b/app/Http/Controllers/Core/V1/TaxonomyServiceEligibilityController.php
@@ -4,13 +4,25 @@ namespace App\Http\Controllers\Core\V1;
 
 use App\Events\EndpointHit;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\TaxonomyServiceEligibility\DestroyRequest;
 use App\Http\Requests\TaxonomyServiceEligibility\IndexRequest;
+use App\Http\Requests\TaxonomyServiceEligibility\ShowRequest;
+use App\Http\Requests\TaxonomyServiceEligibility\StoreRequest;
+use App\Http\Requests\TaxonomyServiceEligibility\UpdateRequest;
 use App\Http\Resources\TaxonomyCategoryResource;
+use App\Http\Responses\ResourceDeleted;
+use App\Models\ServiceEligibility;
 use App\Models\Taxonomy;
+use Illuminate\Support\Facades\DB;
 use Spatie\QueryBuilder\QueryBuilder;
 
 class TaxonomyServiceEligibilityController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware('auth:api')->except('index', 'show');
+    }
+
     /**
      * Display a listing of the resource.
      *
@@ -30,5 +42,102 @@ class TaxonomyServiceEligibilityController extends Controller
         event(EndpointHit::onRead($request, 'Viewed all taxonomy service eligibilities'));
 
         return TaxonomyCategoryResource::collection($serviceEligibilities);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param \App\Http\Requests\TaxonomyServiceEligibility\StoreRequest $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(StoreRequest $request)
+    {
+        return DB::transaction(function () use ($request) {
+            $parent = $request->filled('parent_id')
+                ? Taxonomy::query()->findOrFail($request->parent_id)
+                : Taxonomy::serviceEligibility();
+
+            $serviceEligibility = Taxonomy::create([
+                'parent_id' => $parent->id,
+                'name' => $request->name,
+                'order' => $request->order,
+                'depth' => 0, // Placeholder
+            ]);
+
+            $serviceEligibility->updateDepth();
+
+            event(EndpointHit::onCreate($request, "Created taxonomy service eligibility [{$serviceEligibility->id}]", $serviceEligibility));
+
+            return new TaxonomyCategoryResource($serviceEligibility);
+        });
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param \App\Http\Requests\TaxonomyServiceEligibility\ShowRequest $request
+     * @param \App\Models\Taxonomy $taxonomy
+     * @return \App\Http\Resources\TaxonomyCategoryResource
+     */
+    public function show(ShowRequest $request, Taxonomy $taxonomy)
+    {
+        $baseQuery = Taxonomy::query()
+            ->where('id', $taxonomy->id);
+
+        $taxonomy = QueryBuilder::for($baseQuery)
+            ->firstOrFail();
+
+        event(EndpointHit::onRead($request, "Viewed taxonomy service eligibility [{$taxonomy->id}]", $taxonomy));
+
+        return new TaxonomyCategoryResource($taxonomy->load('children.children.children.children.children.children'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param \App\Http\Requests\TaxonomyServiceEligibility\UpdateRequest $request
+     * @param \App\Models\Taxonomy $taxonomy
+     * @return \Illuminate\Http\Response
+     */
+    public function update(UpdateRequest $request, Taxonomy $taxonomy)
+    {
+        return DB::transaction(function () use ($request, $taxonomy) {
+            $parent = $request->filled('parent_id')
+                ? Taxonomy::query()->findOrFail($request->parent_id)
+                : Taxonomy::serviceEligibility();
+
+            $taxonomy->update([
+                'parent_id' => $parent->id,
+                'name' => $request->name,
+                'order' => $request->order,
+                'depth' => 0, // Placeholder
+            ]);
+
+            $taxonomy->updateDepth();
+
+            event(EndpointHit::onUpdate($request, "Updated taxonomy service eligibility [{$taxonomy->id}]", $taxonomy));
+
+            return new TaxonomyCategoryResource($taxonomy);
+        });
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param \App\Http\Requests\TaxonomyServiceEligibility\DestroyRequest $request
+     * @param \App\Models\Taxonomy $taxonomy
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(DestroyRequest $request, Taxonomy $taxonomy)
+    {
+        return DB::transaction(function () use ($request, $taxonomy) {
+            event(EndpointHit::onDelete($request, "Deleted taxonomy service eligibility [{$taxonomy->id}]", $taxonomy));
+
+            ServiceEligibility::where('taxonomy_id', $taxonomy->id)->delete();
+
+            $taxonomy->delete();
+
+            return new ResourceDeleted('taxonomy service eligibility');
+        });
     }
 }

--- a/app/Http/Requests/TaxonomyServiceEligibility/DestroyRequest.php
+++ b/app/Http/Requests/TaxonomyServiceEligibility/DestroyRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\TaxonomyServiceEligibility;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DestroyRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return $this->user()->isGlobalAdmin();
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Http/Requests/TaxonomyServiceEligibility/ShowRequest.php
+++ b/app/Http/Requests/TaxonomyServiceEligibility/ShowRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\TaxonomyServiceEligibility;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ShowRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Http/Requests/TaxonomyServiceEligibility/StoreRequest.php
+++ b/app/Http/Requests/TaxonomyServiceEligibility/StoreRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\TaxonomyServiceEligibility;
+
+use App\Models\Taxonomy;
+use App\Rules\RootTaxonomyIs;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return $this->user()->isGlobalAdmin();
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        $parentId = $this->parent_id ?? Taxonomy::serviceEligibility()->id;
+        $siblingTaxonomiesCount = Taxonomy::where('parent_id', $parentId)->count() + 1;
+
+        return [
+            'parent_id' => ['present', 'nullable', 'exists:taxonomies,id', new RootTaxonomyIs(Taxonomy::NAME_SERVICE_ELIGIBILITY)],
+            'name' => ['required', 'string', 'min:1', 'max:255'],
+            'order' => ['required', 'integer', 'min:1', "max:$siblingTaxonomiesCount"],
+        ];
+    }
+}

--- a/app/Http/Requests/TaxonomyServiceEligibility/UpdateRequest.php
+++ b/app/Http/Requests/TaxonomyServiceEligibility/UpdateRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Requests\TaxonomyServiceEligibility;
+
+use App\Models\Taxonomy;
+use App\Rules\RootTaxonomyIs;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return $this->user()->isGlobalAdmin();
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        // Get the new parent ID.
+        $parentId = $this->parent_id ?? Taxonomy::serviceEligibility()->id;
+
+        // Check if the parent taxonomy remained the same.
+        $hasSameParent = $this->taxonomy->parent_id === $parentId;
+
+        // Get the sibling count for the same parent.
+        $siblingTaxonomiesCount = Taxonomy::where('parent_id', $parentId)->count();
+
+        // Increment the sibling count if the parent is new.
+        $siblingTaxonomiesCount = $hasSameParent ? $siblingTaxonomiesCount : $siblingTaxonomiesCount + 1;
+
+        return [
+            'parent_id' => ['present', 'nullable', 'exists:taxonomies,id', new RootTaxonomyIs(Taxonomy::NAME_SERVICE_ELIGIBILITY)],
+            'name' => ['required', 'string', 'min:1', 'max:255'],
+            'order' => ['required', 'integer', 'min:1', "max:$siblingTaxonomiesCount"],
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -173,6 +173,15 @@ Route::prefix('/core/v1')
 
             // Taxonomy Service Eligibility.
             Route::get('/taxonomies/service-eligibilities', 'TaxonomyServiceEligibilityController@index');
+            Route::apiResource('/taxonomies/service-eligibilities', 'TaxonomyServiceEligibilityController')
+                ->parameter('service-eligibilities', 'taxonomy')
+                ->names([
+                    'index' => 'taxonomy-service-eligibilities.index',
+                    'store' => 'taxonomy-service-eligibilities.store',
+                    'show' => 'taxonomy-service-eligibilities.show',
+                    'update' => 'taxonomy-service-eligibilities.update',
+                    'destroy' => 'taxonomy-service-eligibilities.destroy',
+                ]);
 
             // Thesaurus.
             Route::get('/thesaurus', 'ThesaurusController@index')

--- a/tests/Feature/TaxonomyServiceEligibilityTest.php
+++ b/tests/Feature/TaxonomyServiceEligibilityTest.php
@@ -74,7 +74,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
 
     public function test_guest_cannot_create_one()
     {
-        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibility');
+        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibilities');
 
         $response->assertStatus(Response::HTTP_UNAUTHORIZED);
     }
@@ -86,7 +86,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
 
         Passport::actingAs($user);
 
-        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibility');
+        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibilities');
 
         $response->assertStatus(Response::HTTP_FORBIDDEN);
     }
@@ -98,7 +98,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
 
         Passport::actingAs($user);
 
-        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibility');
+        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibilities');
 
         $response->assertStatus(Response::HTTP_FORBIDDEN);
     }
@@ -110,7 +110,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
 
         Passport::actingAs($user);
 
-        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibility');
+        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibilities');
 
         $response->assertStatus(Response::HTTP_FORBIDDEN);
     }
@@ -126,10 +126,14 @@ class TaxonomyServiceEligibilityTest extends TestCase
         ];
 
         Passport::actingAs($user);
-        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibility', $payload);
+        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibilities', $payload);
 
         $response->assertStatus(Response::HTTP_CREATED);
-        $response->assertJsonFragment($payload);
+        $response->assertJsonFragment([
+            'parent_id' => Taxonomy::serviceEligibility()->id,
+            'name' => 'PHPUnit Service Eligibility Test',
+            'order' => $siblingCount + 1,
+        ]);
     }
 
     public function test_order_is_updated_when_created_at_beginning()
@@ -151,7 +155,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
         ];
 
         Passport::actingAs($user);
-        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibility', $payload);
+        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibilities', $payload);
 
         $response->assertStatus(Response::HTTP_CREATED);
         $response->assertJsonFragment($payload);
@@ -182,7 +186,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
         ];
 
         Passport::actingAs($user);
-        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibility', $payload);
+        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibilities', $payload);
 
         $response->assertStatus(Response::HTTP_CREATED);
         $response->assertJsonFragment($payload);
@@ -220,7 +224,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
         ];
 
         Passport::actingAs($user);
-        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibility', $payload);
+        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibilities', $payload);
 
         $response->assertStatus(Response::HTTP_CREATED);
         $response->assertJsonFragment($payload);
@@ -242,7 +246,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
         ];
 
         Passport::actingAs($user);
-        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibility', $payload);
+        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibilities', $payload);
 
         $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
     }
@@ -250,7 +254,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
     public function test_order_cannot_be_greater_than_count_plus_1_when_created()
     {
         $user = factory(User::class)->create()->makeGlobalAdmin();
-        $siblingCount = Taxonomy::category()->children()->count();
+        $siblingCount = Taxonomy::serviceEligibility()->children()->count();
         $payload = [
             'parent_id' => null,
             'name' => 'PHPUnit Service Eligibility Test',
@@ -258,7 +262,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
         ];
 
         Passport::actingAs($user);
-        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibility', $payload);
+        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibilities', $payload);
 
         $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
     }
@@ -268,10 +272,10 @@ class TaxonomyServiceEligibilityTest extends TestCase
         $this->fakeEvents();
 
         $user = factory(User::class)->create()->makeGlobalAdmin();
-        $siblingCount = Taxonomy::category()->children()->count();
+        $siblingCount = Taxonomy::serviceEligibility()->children()->count();
 
         Passport::actingAs($user);
-        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibility', [
+        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibilities', [
             'parent_id' => null,
             'name' => 'PHPUnit Service Eligibility Test',
             'order' => $siblingCount + 1,
@@ -294,7 +298,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
             'parent_id' => $this->testserviceEligibilityType->id,
         ]);
 
-        $response = $this->json('GET', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}");
+        $response = $this->json('GET', "/core/v1/taxonomies/service-eligibilities/{$testEligibilityTypeTaxonomy->id}");
 
         $response->assertStatus(Response::HTTP_OK);
         $response->assertJsonFragment([
@@ -318,7 +322,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
             'parent_id' => $this->testserviceEligibilityType->id,
         ]);
 
-        $this->json('GET', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}");
+        $this->json('GET', "/core/v1/taxonomies/service-eligibilities/{$testEligibilityTypeTaxonomy->id}");
 
         Event::assertDispatched(EndpointHit::class, function (EndpointHit $event) use ($testEligibilityTypeTaxonomy) {
             return ($event->getAction() === Audit::ACTION_READ) &&
@@ -336,7 +340,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
             'parent_id' => $this->testserviceEligibilityType->id,
         ]);
 
-        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}");
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibilities/{$testEligibilityTypeTaxonomy->id}");
 
         $response->assertStatus(Response::HTTP_UNAUTHORIZED);
     }
@@ -350,7 +354,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
         ]);
 
         Passport::actingAs($user);
-        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}");
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibilities/{$testEligibilityTypeTaxonomy->id}");
 
         $response->assertStatus(Response::HTTP_FORBIDDEN);
     }
@@ -364,7 +368,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
         ]);
 
         Passport::actingAs($user);
-        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}");
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibilities/{$testEligibilityTypeTaxonomy->id}");
 
         $response->assertStatus(Response::HTTP_FORBIDDEN);
     }
@@ -378,7 +382,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
         ]);
 
         Passport::actingAs($user);
-        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}");
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibilities/{$testEligibilityTypeTaxonomy->id}");
 
         $response->assertStatus(Response::HTTP_FORBIDDEN);
     }
@@ -392,11 +396,11 @@ class TaxonomyServiceEligibilityTest extends TestCase
         $payload = [
             'parent_id' => $testEligibilityTypeTaxonomy->parent_id,
             'name' => 'PHPUnit Test Service Eligibility',
-            'order' => $testEligibilityTypeTaxonomy->order,
+            'order' => 1,
         ];
 
         Passport::actingAs($user);
-        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}", $payload);
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibilities/{$testEligibilityTypeTaxonomy->id}", $payload);
 
         $response->assertStatus(Response::HTTP_OK);
         $response->assertJsonFragment($payload);
@@ -404,7 +408,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
 
     public function test_order_is_updated_when_updated_to_beginning()
     {
-        $user = factory(User::class)->create()->makeSuperAdmin();
+        $user = factory(User::class)->create()->makeGlobalAdmin();
         Passport::actingAs($user);
 
         $eligibilityOne = $this->testserviceEligibilityType->children()->create([
@@ -423,7 +427,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
             'depth' => 1,
         ]);
 
-        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$eligibilityTwo->id}", [
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibilities/{$eligibilityTwo->id}", [
             'parent_id' => $eligibilityTwo->parent_id,
             'name' => $eligibilityTwo->name,
             'order' => 1,
@@ -437,7 +441,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
 
     public function test_order_is_updated_when_updated_to_middle()
     {
-        $user = factory(User::class)->create()->makeSuperAdmin();
+        $user = factory(User::class)->create()->makeGlobalAdmin();
         Passport::actingAs($user);
 
         $eligibilityOne = $this->testserviceEligibilityType->children()->create([
@@ -456,7 +460,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
             'depth' => 1,
         ]);
 
-        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$eligibilityOne->id}", [
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibilities/{$eligibilityOne->id}", [
             'parent_id' => $eligibilityOne->parent_id,
             'name' => $eligibilityOne->name,
             'order' => 2,
@@ -470,7 +474,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
 
     public function test_order_is_updated_when_updated_to_end()
     {
-        $user = factory(User::class)->create()->makeSuperAdmin();
+        $user = factory(User::class)->create()->makeGlobalAdmin();
         Passport::actingAs($user);
 
         $eligibilityOne = $this->testserviceEligibilityType->children()->create([
@@ -489,7 +493,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
             'depth' => 1,
         ]);
 
-        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$eligibilityTwo->id}", [
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibilities/{$eligibilityTwo->id}", [
             'parent_id' => $eligibilityTwo->parent_id,
             'name' => $eligibilityTwo->name,
             'order' => 3,
@@ -503,7 +507,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
 
     public function test_order_is_updated_when_updated_to_beginning_of_another_parent()
     {
-        $user = factory(User::class)->create()->makeSuperAdmin();
+        $user = factory(User::class)->create()->makeGlobalAdmin();
         Passport::actingAs($user);
 
         $oldEligibilityOne = $this->testserviceEligibilityType->children()->create([
@@ -544,7 +548,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
             'depth' => 1,
         ]);
 
-        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$oldEligibilityTwo->id}", [
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibilities/{$oldEligibilityTwo->id}", [
             'parent_id' => $newParentEligibility->id,
             'name' => $oldEligibilityTwo->name,
             'order' => 1,
@@ -593,7 +597,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
 
     public function test_order_is_updated_when_updated_to_middle_of_another_parent()
     {
-        $user = factory(User::class)->create()->makeSuperAdmin();
+        $user = factory(User::class)->create()->makeGlobalAdmin();
         Passport::actingAs($user);
 
         $oldEligibilityOne = $this->testserviceEligibilityType->children()->create([
@@ -634,7 +638,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
             'depth' => 1,
         ]);
 
-        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$oldEligibilityOne->id}", [
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibilities/{$oldEligibilityOne->id}", [
             'parent_id' => $newParentEligibility->id,
             'name' => $oldEligibilityOne->name,
             'order' => 2,
@@ -683,7 +687,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
 
     public function test_order_is_updated_when_updated_to_end_of_another_parent()
     {
-        $user = factory(User::class)->create()->makeSuperAdmin();
+        $user = factory(User::class)->create()->makeGlobalAdmin();
         Passport::actingAs($user);
 
         $oldEligibilityOne = $this->testserviceEligibilityType->children()->create([
@@ -724,7 +728,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
             'depth' => 1,
         ]);
 
-        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$oldEligibilityTwo->id}", [
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibilities/{$oldEligibilityTwo->id}", [
             'parent_id' => $newParentEligibility->id,
             'name' => $oldEligibilityTwo->name,
             'order' => 4,
@@ -773,14 +777,14 @@ class TaxonomyServiceEligibilityTest extends TestCase
 
     public function test_order_cannot_be_less_than_1_when_updated()
     {
-        $user = factory(User::class)->create()->makeSuperAdmin();
+        $user = factory(User::class)->create()->makeGlobalAdmin();
         Passport::actingAs($user);
 
         $testEligibilityTypeTaxonomy = factory(Taxonomy::class)->create([
             'parent_id' => $this->testserviceEligibilityType->id,
         ]);
 
-        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}", [
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibilities/{$testEligibilityTypeTaxonomy->id}", [
             'parent_id' => $testEligibilityTypeTaxonomy->parent_id,
             'name' => $testEligibilityTypeTaxonomy->name,
             'order' => 0,
@@ -791,14 +795,14 @@ class TaxonomyServiceEligibilityTest extends TestCase
 
     public function test_order_cannot_be_greater_than_count_plus_1_when_updated()
     {
-        $user = factory(User::class)->create()->makeSuperAdmin();
+        $user = factory(User::class)->create()->makeGlobalAdmin();
         Passport::actingAs($user);
 
         $testEligibilityTypeTaxonomies = factory(Taxonomy::class, 5)->create([
             'parent_id' => $this->testserviceEligibilityType->id,
         ]);
 
-        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomies->get(0)->id}", [
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibilities/{$testEligibilityTypeTaxonomies->get(0)->id}", [
             'parent_id' => $this->testserviceEligibilityType->id,
             'name' => $testEligibilityTypeTaxonomies->get(0)->name,
             'order' => 6,
@@ -811,17 +815,19 @@ class TaxonomyServiceEligibilityTest extends TestCase
     {
         $this->fakeEvents();
 
-        $user = factory(User::class)->create()->makeSuperAdmin();
+        $user = factory(User::class)->create()->makeGlobalAdmin();
         $testEligibilityTypeTaxonomy = factory(Taxonomy::class)->create([
             'parent_id' => $this->testserviceEligibilityType->id,
         ]);
 
         Passport::actingAs($user);
-        $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}", [
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibilities/{$testEligibilityTypeTaxonomy->id}", [
             'parent_id' => $testEligibilityTypeTaxonomy->parent_id,
             'name' => 'PHPUnit Test Eligibility Type Taxonomy',
-            'order' => $testEligibilityTypeTaxonomy->order,
+            'order' => 1,
         ]);
+
+        $response->assertStatus(Response::HTTP_OK);
 
         Event::assertDispatched(EndpointHit::class, function (EndpointHit $event) use ($user, $testEligibilityTypeTaxonomy) {
             return ($event->getAction() === Audit::ACTION_UPDATE) &&
@@ -840,7 +846,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
             'parent_id' => $this->testserviceEligibilityType->id,
         ]);
 
-        $response = $this->json('DELETE', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}");
+        $response = $this->json('DELETE', "/core/v1/taxonomies/service-eligibilities/{$testEligibilityTypeTaxonomy->id}");
 
         $response->assertStatus(Response::HTTP_UNAUTHORIZED);
     }
@@ -854,7 +860,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
         ]);
 
         Passport::actingAs($user);
-        $response = $this->json('DELETE', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}");
+        $response = $this->json('DELETE', "/core/v1/taxonomies/service-eligibilities/{$testEligibilityTypeTaxonomy->id}");
 
         $response->assertStatus(Response::HTTP_FORBIDDEN);
     }
@@ -868,7 +874,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
         ]);
 
         Passport::actingAs($user);
-        $response = $this->json('DELETE', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}");
+        $response = $this->json('DELETE', "/core/v1/taxonomies/service-eligibilities/{$testEligibilityTypeTaxonomy->id}");
 
         $response->assertStatus(Response::HTTP_FORBIDDEN);
     }
@@ -882,7 +888,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
         ]);
 
         Passport::actingAs($user);
-        $response = $this->json('DELETE', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}");
+        $response = $this->json('DELETE', "/core/v1/taxonomies/service-eligibilities/{$testEligibilityTypeTaxonomy->id}");
 
         $response->assertStatus(Response::HTTP_FORBIDDEN);
     }
@@ -896,12 +902,12 @@ class TaxonomyServiceEligibilityTest extends TestCase
                 return Taxonomy::serviceEligibility()->id;
             },
         ]);
-        $childEligibilities = factory(Taxonomy::class)->create([
+        $childEligibilities = factory(Taxonomy::class, 5)->create([
             'parent_id' => $newParentEligibility->id,
         ]);
 
         Passport::actingAs($user);
-        $response = $this->json('DELETE', "/core/v1/taxonomies/service-eligibility/{$newParentEligibility->id}");
+        $response = $this->json('DELETE', "/core/v1/taxonomies/service-eligibilities/{$newParentEligibility->id}");
 
         $response->assertStatus(Response::HTTP_OK);
         $this->assertDatabaseMissing((new Taxonomy())->getTable(), ['id' => $newParentEligibility->id]);
@@ -926,7 +932,7 @@ class TaxonomyServiceEligibilityTest extends TestCase
         ]);
 
         Passport::actingAs($user);
-        $this->json('DELETE', "/core/v1/taxonomies/service-eligibility/{$newParentEligibility->id}");
+        $this->json('DELETE', "/core/v1/taxonomies/service-eligibilities/{$newParentEligibility->id}");
 
         Event::assertDispatched(EndpointHit::class, function (EndpointHit $event) use ($user, $newParentEligibility) {
             return ($event->getAction() === Audit::ACTION_DELETE) &&
@@ -956,9 +962,10 @@ class TaxonomyServiceEligibilityTest extends TestCase
         ]);
 
         Passport::actingAs($user);
-        $response = $this->json('DELETE', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}");
+        $response = $this->json('DELETE', "/core/v1/taxonomies/service-eligibilities/{$testEligibilityTypeTaxonomy->id}");
 
         $response->assertStatus(Response::HTTP_OK);
+
         $this->assertDatabaseMissing((new ServiceEligibility())->getTable(), [
             'service_id' => $service->id,
             'taxonomy_id' => $testEligibilityTypeTaxonomy->id,

--- a/tests/Feature/TaxonomyServiceEligibilityTest.php
+++ b/tests/Feature/TaxonomyServiceEligibilityTest.php
@@ -6,12 +6,12 @@ use App\Events\EndpointHit;
 use App\Models\Audit;
 use App\Models\Organisation;
 use App\Models\Service;
-use App\Models\SocialMedia;
+use App\Models\ServiceEligibility;
 use App\Models\Taxonomy;
+use App\Models\User;
+use Carbon\CarbonImmutable;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Event;
-use App\Models\UpdateRequest;
-use App\Models\User;
 use Laravel\Passport\Passport;
 use Tests\TestCase;
 
@@ -21,10 +21,17 @@ class TaxonomyServiceEligibilityTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        $this->testserviceEligibilityType = factory(Taxonomy::class)->create([
+            'name' => 'Test Service Eligibility Type',
+            'parent_id' => function () {
+                return Taxonomy::serviceEligibility()->id;
+            },
+        ]);
     }
 
     /*
-     * List all the category taxonomies.
+     * List all the service eligibility taxonomies.
      */
 
     public function test_guest_can_list_them()
@@ -59,5 +66,902 @@ class TaxonomyServiceEligibilityTest extends TestCase
         Event::assertDispatched(EndpointHit::class, function (EndpointHit $event) {
             return ($event->getAction() === Audit::ACTION_READ);
         });
+    }
+
+    /*
+     * Create a service eligibility taxonomy.
+     */
+
+    public function test_guest_cannot_create_one()
+    {
+        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibility');
+
+        $response->assertStatus(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function test_service_worker_cannot_create_one()
+    {
+        $service = factory(Service::class)->create();
+        $user = factory(User::class)->create()->makeServiceWorker($service);
+
+        Passport::actingAs($user);
+
+        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibility');
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_service_admin_cannot_create_one()
+    {
+        $service = factory(Service::class)->create();
+        $user = factory(User::class)->create()->makeServiceAdmin($service);
+
+        Passport::actingAs($user);
+
+        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibility');
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_organisation_admin_cannot_create_one()
+    {
+        $organisation = factory(Organisation::class)->create();
+        $user = factory(User::class)->create()->makeOrganisationAdmin($organisation);
+
+        Passport::actingAs($user);
+
+        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibility');
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_global_admin_can_create_one()
+    {
+        $user = factory(User::class)->create()->makeGlobalAdmin();
+        $siblingCount = Taxonomy::serviceEligibility()->children()->count();
+        $payload = [
+            'parent_id' => null,
+            'name' => 'PHPUnit Service Eligibility Test',
+            'order' => $siblingCount + 1,
+        ];
+
+        Passport::actingAs($user);
+        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibility', $payload);
+
+        $response->assertStatus(Response::HTTP_CREATED);
+        $response->assertJsonFragment($payload);
+    }
+
+    public function test_order_is_updated_when_created_at_beginning()
+    {
+        $user = factory(User::class)->create()->makeGlobalAdmin();
+
+        $testEligibilityTypeTaxonomies = [];
+        for ($i = 1; $i < 6; $i++) {
+            $testEligibilityTypeTaxonomies[] = factory(Taxonomy::class)->create([
+                'parent_id' => $this->testserviceEligibilityType->id,
+                'order' => $i,
+            ]);
+        }
+
+        $payload = [
+            'parent_id' => $this->testserviceEligibilityType->id,
+            'name' => 'PHPUnit Service Eligibility Test',
+            'order' => 1,
+        ];
+
+        Passport::actingAs($user);
+        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibility', $payload);
+
+        $response->assertStatus(Response::HTTP_CREATED);
+        $response->assertJsonFragment($payload);
+        foreach ($testEligibilityTypeTaxonomies as $eligibility) {
+            $this->assertDatabaseHas(
+                (new Taxonomy())->getTable(),
+                ['id' => $eligibility->id, 'order' => $eligibility->order + 1]
+            );
+        }
+    }
+
+    public function test_order_is_updated_when_created_at_middle()
+    {
+        $user = factory(User::class)->create()->makeGlobalAdmin();
+
+        $testEligibilityTypeTaxonomies = [];
+        for ($i = 1; $i < 6; $i++) {
+            $testEligibilityTypeTaxonomies[] = factory(Taxonomy::class)->create([
+                'parent_id' => $this->testserviceEligibilityType->id,
+                'order' => $i,
+            ]);
+        }
+
+        $payload = [
+            'parent_id' => $this->testserviceEligibilityType->id,
+            'name' => 'PHPUnit Service Eligibility Test',
+            'order' => 2,
+        ];
+
+        Passport::actingAs($user);
+        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibility', $payload);
+
+        $response->assertStatus(Response::HTTP_CREATED);
+        $response->assertJsonFragment($payload);
+        foreach ($testEligibilityTypeTaxonomies as $eligibility) {
+            if ($eligibility->order < 2) {
+                $this->assertDatabaseHas(
+                    (new Taxonomy())->getTable(),
+                    ['id' => $eligibility->id, 'order' => $eligibility->order]
+                );
+            } else {
+                $this->assertDatabaseHas(
+                    (new Taxonomy())->getTable(),
+                    ['id' => $eligibility->id, 'order' => $eligibility->order + 1]
+                );
+            }
+        }
+    }
+
+    public function test_order_is_updated_when_created_at_end()
+    {
+        $user = factory(User::class)->create()->makeGlobalAdmin();
+
+        $testEligibilityTypeTaxonomies = [];
+        for ($i = 1; $i < 6; $i++) {
+            $testEligibilityTypeTaxonomies[] = factory(Taxonomy::class)->create([
+                'parent_id' => $this->testserviceEligibilityType->id,
+                'order' => $i,
+            ]);
+        }
+
+        $payload = [
+            'parent_id' => $this->testserviceEligibilityType->id,
+            'name' => 'PHPUnit Service Eligibility Test',
+            'order' => count($testEligibilityTypeTaxonomies) + 1,
+        ];
+
+        Passport::actingAs($user);
+        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibility', $payload);
+
+        $response->assertStatus(Response::HTTP_CREATED);
+        $response->assertJsonFragment($payload);
+        foreach ($testEligibilityTypeTaxonomies as $eligibility) {
+            $this->assertDatabaseHas(
+                (new Taxonomy())->getTable(),
+                ['id' => $eligibility->id, 'order' => $eligibility->order]
+            );
+        }
+    }
+
+    public function test_order_cannot_be_less_than_1_when_created()
+    {
+        $user = factory(User::class)->create()->makeGlobalAdmin();
+        $payload = [
+            'parent_id' => null,
+            'name' => 'PHPUnit Service Eligibility Test',
+            'order' => 0,
+        ];
+
+        Passport::actingAs($user);
+        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibility', $payload);
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    public function test_order_cannot_be_greater_than_count_plus_1_when_created()
+    {
+        $user = factory(User::class)->create()->makeGlobalAdmin();
+        $siblingCount = Taxonomy::category()->children()->count();
+        $payload = [
+            'parent_id' => null,
+            'name' => 'PHPUnit Service Eligibility Test',
+            'order' => $siblingCount + 2,
+        ];
+
+        Passport::actingAs($user);
+        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibility', $payload);
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    public function test_audit_created_when_created()
+    {
+        $this->fakeEvents();
+
+        $user = factory(User::class)->create()->makeGlobalAdmin();
+        $siblingCount = Taxonomy::category()->children()->count();
+
+        Passport::actingAs($user);
+        $response = $this->json('POST', '/core/v1/taxonomies/service-eligibility', [
+            'parent_id' => null,
+            'name' => 'PHPUnit Service Eligibility Test',
+            'order' => $siblingCount + 1,
+        ]);
+
+        Event::assertDispatched(EndpointHit::class, function (EndpointHit $event) use ($user, $response) {
+            return ($event->getAction() === Audit::ACTION_CREATE) &&
+                ($event->getUser()->id === $user->id) &&
+                ($event->getModel()->id === $this->getResponseContent($response)['data']['id']);
+        });
+    }
+
+    /*
+     * Get a service eligibility taxonomy
+     */
+
+    public function test_guest_can_view_one()
+    {
+        $testEligibilityTypeTaxonomy = factory(Taxonomy::class)->create([
+            'parent_id' => $this->testserviceEligibilityType->id,
+        ]);
+
+        $response = $this->json('GET', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}");
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJsonFragment([
+            [
+                'id' => $testEligibilityTypeTaxonomy->id,
+                'parent_id' => $testEligibilityTypeTaxonomy->parent_id,
+                'name' => $testEligibilityTypeTaxonomy->name,
+                'order' => $testEligibilityTypeTaxonomy->order,
+                'children' => [],
+                'created_at' => $testEligibilityTypeTaxonomy->created_at->format(CarbonImmutable::ISO8601),
+                'updated_at' => $testEligibilityTypeTaxonomy->updated_at->format(CarbonImmutable::ISO8601),
+            ],
+        ]);
+    }
+
+    public function test_audit_created_when_viewed()
+    {
+        $this->fakeEvents();
+
+        $testEligibilityTypeTaxonomy = factory(Taxonomy::class)->create([
+            'parent_id' => $this->testserviceEligibilityType->id,
+        ]);
+
+        $this->json('GET', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}");
+
+        Event::assertDispatched(EndpointHit::class, function (EndpointHit $event) use ($testEligibilityTypeTaxonomy) {
+            return ($event->getAction() === Audit::ACTION_READ) &&
+                ($event->getModel()->id === $testEligibilityTypeTaxonomy->id);
+        });
+    }
+
+    /*
+     * Update a specific service eligibility taxonomy.
+     */
+
+    public function test_guest_cannot_update_one()
+    {
+        $testEligibilityTypeTaxonomy = factory(Taxonomy::class)->create([
+            'parent_id' => $this->testserviceEligibilityType->id,
+        ]);
+
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}");
+
+        $response->assertStatus(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function test_service_worker_cannot_update_one()
+    {
+        $service = factory(Service::class)->create();
+        $user = factory(User::class)->create()->makeServiceWorker($service);
+        $testEligibilityTypeTaxonomy = factory(Taxonomy::class)->create([
+            'parent_id' => $this->testserviceEligibilityType->id,
+        ]);
+
+        Passport::actingAs($user);
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}");
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_service_admin_cannot_update_one()
+    {
+        $service = factory(Service::class)->create();
+        $user = factory(User::class)->create()->makeServiceAdmin($service);
+        $testEligibilityTypeTaxonomy = factory(Taxonomy::class)->create([
+            'parent_id' => $this->testserviceEligibilityType->id,
+        ]);
+
+        Passport::actingAs($user);
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}");
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_organisation_admin_cannot_update_one()
+    {
+        $organisation = factory(Organisation::class)->create();
+        $user = factory(User::class)->create()->makeOrganisationAdmin($organisation);
+        $testEligibilityTypeTaxonomy = factory(Taxonomy::class)->create([
+            'parent_id' => $this->testserviceEligibilityType->id,
+        ]);
+
+        Passport::actingAs($user);
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}");
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_global_admin_can_update_one()
+    {
+        $user = factory(User::class)->create()->makeGlobalAdmin();
+        $testEligibilityTypeTaxonomy = factory(Taxonomy::class)->create([
+            'parent_id' => $this->testserviceEligibilityType->id,
+        ]);
+        $payload = [
+            'parent_id' => $testEligibilityTypeTaxonomy->parent_id,
+            'name' => 'PHPUnit Test Service Eligibility',
+            'order' => $testEligibilityTypeTaxonomy->order,
+        ];
+
+        Passport::actingAs($user);
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}", $payload);
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJsonFragment($payload);
+    }
+
+    public function test_order_is_updated_when_updated_to_beginning()
+    {
+        $user = factory(User::class)->create()->makeSuperAdmin();
+        Passport::actingAs($user);
+
+        $eligibilityOne = $this->testserviceEligibilityType->children()->create([
+            'name' => 'One',
+            'order' => 1,
+            'depth' => 1,
+        ]);
+        $eligibilityTwo = $this->testserviceEligibilityType->children()->create([
+            'name' => 'Two',
+            'order' => 2,
+            'depth' => 1,
+        ]);
+        $eligibilityThree = $this->testserviceEligibilityType->children()->create([
+            'name' => 'Three',
+            'order' => 3,
+            'depth' => 1,
+        ]);
+
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$eligibilityTwo->id}", [
+            'parent_id' => $eligibilityTwo->parent_id,
+            'name' => $eligibilityTwo->name,
+            'order' => 1,
+        ]);
+
+        $response->assertStatus(Response::HTTP_OK);
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), ['id' => $eligibilityOne->id, 'order' => 2]);
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), ['id' => $eligibilityTwo->id, 'order' => 1]);
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), ['id' => $eligibilityThree->id, 'order' => 3]);
+    }
+
+    public function test_order_is_updated_when_updated_to_middle()
+    {
+        $user = factory(User::class)->create()->makeSuperAdmin();
+        Passport::actingAs($user);
+
+        $eligibilityOne = $this->testserviceEligibilityType->children()->create([
+            'name' => 'One',
+            'order' => 1,
+            'depth' => 1,
+        ]);
+        $eligibilityTwo = $this->testserviceEligibilityType->children()->create([
+            'name' => 'Two',
+            'order' => 2,
+            'depth' => 1,
+        ]);
+        $eligibilityThree = $this->testserviceEligibilityType->children()->create([
+            'name' => 'Three',
+            'order' => 3,
+            'depth' => 1,
+        ]);
+
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$eligibilityOne->id}", [
+            'parent_id' => $eligibilityOne->parent_id,
+            'name' => $eligibilityOne->name,
+            'order' => 2,
+        ]);
+
+        $response->assertStatus(Response::HTTP_OK);
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), ['id' => $eligibilityOne->id, 'order' => 2]);
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), ['id' => $eligibilityTwo->id, 'order' => 1]);
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), ['id' => $eligibilityThree->id, 'order' => 3]);
+    }
+
+    public function test_order_is_updated_when_updated_to_end()
+    {
+        $user = factory(User::class)->create()->makeSuperAdmin();
+        Passport::actingAs($user);
+
+        $eligibilityOne = $this->testserviceEligibilityType->children()->create([
+            'name' => 'One',
+            'order' => 1,
+            'depth' => 1,
+        ]);
+        $eligibilityTwo = $this->testserviceEligibilityType->children()->create([
+            'name' => 'Two',
+            'order' => 2,
+            'depth' => 1,
+        ]);
+        $eligibilityThree = $this->testserviceEligibilityType->children()->create([
+            'name' => 'Three',
+            'order' => 3,
+            'depth' => 1,
+        ]);
+
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$eligibilityTwo->id}", [
+            'parent_id' => $eligibilityTwo->parent_id,
+            'name' => $eligibilityTwo->name,
+            'order' => 3,
+        ]);
+
+        $response->assertStatus(Response::HTTP_OK);
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), ['id' => $eligibilityOne->id, 'order' => 1]);
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), ['id' => $eligibilityTwo->id, 'order' => 3]);
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), ['id' => $eligibilityThree->id, 'order' => 2]);
+    }
+
+    public function test_order_is_updated_when_updated_to_beginning_of_another_parent()
+    {
+        $user = factory(User::class)->create()->makeSuperAdmin();
+        Passport::actingAs($user);
+
+        $oldEligibilityOne = $this->testserviceEligibilityType->children()->create([
+            'name' => 'One',
+            'order' => 1,
+            'depth' => 1,
+        ]);
+        $oldEligibilityTwo = $this->testserviceEligibilityType->children()->create([
+            'name' => 'Two',
+            'order' => 2,
+            'depth' => 1,
+        ]);
+        $oldEligibilityThree = $this->testserviceEligibilityType->children()->create([
+            'name' => 'Three',
+            'order' => 3,
+            'depth' => 1,
+        ]);
+
+        $newParentEligibility = factory(Taxonomy::class)->create([
+            'name' => 'New Service Eligibility Type',
+            'parent_id' => function () {
+                return Taxonomy::serviceEligibility()->id;
+            },
+        ]);
+        $newEligibilityOne = $newParentEligibility->children()->create([
+            'name' => 'One',
+            'order' => 1,
+            'depth' => 1,
+        ]);
+        $newEligibilityTwo = $newParentEligibility->children()->create([
+            'name' => 'Two',
+            'order' => 2,
+            'depth' => 1,
+        ]);
+        $newEligibilityThree = $newParentEligibility->children()->create([
+            'name' => 'Three',
+            'order' => 3,
+            'depth' => 1,
+        ]);
+
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$oldEligibilityTwo->id}", [
+            'parent_id' => $newParentEligibility->id,
+            'name' => $oldEligibilityTwo->name,
+            'order' => 1,
+        ]);
+
+        $response->assertStatus(Response::HTTP_OK);
+
+        /*
+         * Old parent.
+         */
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), [
+            'parent_id' => $this->testserviceEligibilityType->id,
+            'id' => $oldEligibilityOne->id,
+            'order' => 1,
+        ]);
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), [
+            'parent_id' => $this->testserviceEligibilityType->id,
+            'id' => $oldEligibilityThree->id,
+            'order' => 2,
+        ]);
+
+        /*
+         * New parent.
+         */
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), [
+            'parent_id' => $newParentEligibility->id,
+            'id' => $oldEligibilityTwo->id,
+            'order' => 1,
+        ]);
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), [
+            'parent_id' => $newParentEligibility->id,
+            'id' => $newEligibilityOne->id,
+            'order' => 2,
+        ]);
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), [
+            'parent_id' => $newParentEligibility->id,
+            'id' => $newEligibilityTwo->id,
+            'order' => 3,
+        ]);
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), [
+            'parent_id' => $newParentEligibility->id,
+            'id' => $newEligibilityThree->id,
+            'order' => 4,
+        ]);
+    }
+
+    public function test_order_is_updated_when_updated_to_middle_of_another_parent()
+    {
+        $user = factory(User::class)->create()->makeSuperAdmin();
+        Passport::actingAs($user);
+
+        $oldEligibilityOne = $this->testserviceEligibilityType->children()->create([
+            'name' => 'One',
+            'order' => 1,
+            'depth' => 1,
+        ]);
+        $oldEligibilityTwo = $this->testserviceEligibilityType->children()->create([
+            'name' => 'Two',
+            'order' => 2,
+            'depth' => 1,
+        ]);
+        $oldEligibilityThree = $this->testserviceEligibilityType->children()->create([
+            'name' => 'Three',
+            'order' => 3,
+            'depth' => 1,
+        ]);
+
+        $newParentEligibility = factory(Taxonomy::class)->create([
+            'name' => 'New Service Eligibility Type',
+            'parent_id' => function () {
+                return Taxonomy::serviceEligibility()->id;
+            },
+        ]);
+        $newEligibilityOne = $newParentEligibility->children()->create([
+            'name' => 'One',
+            'order' => 1,
+            'depth' => 1,
+        ]);
+        $newEligibilityTwo = $newParentEligibility->children()->create([
+            'name' => 'Two',
+            'order' => 2,
+            'depth' => 1,
+        ]);
+        $newEligibilityThree = $newParentEligibility->children()->create([
+            'name' => 'Three',
+            'order' => 3,
+            'depth' => 1,
+        ]);
+
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$oldEligibilityOne->id}", [
+            'parent_id' => $newParentEligibility->id,
+            'name' => $oldEligibilityOne->name,
+            'order' => 2,
+        ]);
+
+        $response->assertStatus(Response::HTTP_OK);
+
+        /*
+         * Old parent.
+         */
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), [
+            'parent_id' => $this->testserviceEligibilityType->id,
+            'id' => $oldEligibilityTwo->id,
+            'order' => 1,
+        ]);
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), [
+            'parent_id' => $this->testserviceEligibilityType->id,
+            'id' => $oldEligibilityThree->id,
+            'order' => 2,
+        ]);
+
+        /*
+         * New parent.
+         */
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), [
+            'parent_id' => $newParentEligibility->id,
+            'id' => $newEligibilityOne->id,
+            'order' => 1,
+        ]);
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), [
+            'parent_id' => $newParentEligibility->id,
+            'id' => $oldEligibilityOne->id,
+            'order' => 2,
+        ]);
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), [
+            'parent_id' => $newParentEligibility->id,
+            'id' => $newEligibilityTwo->id,
+            'order' => 3,
+        ]);
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), [
+            'parent_id' => $newParentEligibility->id,
+            'id' => $newEligibilityThree->id,
+            'order' => 4,
+        ]);
+    }
+
+    public function test_order_is_updated_when_updated_to_end_of_another_parent()
+    {
+        $user = factory(User::class)->create()->makeSuperAdmin();
+        Passport::actingAs($user);
+
+        $oldEligibilityOne = $this->testserviceEligibilityType->children()->create([
+            'name' => 'One',
+            'order' => 1,
+            'depth' => 1,
+        ]);
+        $oldEligibilityTwo = $this->testserviceEligibilityType->children()->create([
+            'name' => 'Two',
+            'order' => 2,
+            'depth' => 1,
+        ]);
+        $oldEligibilityThree = $this->testserviceEligibilityType->children()->create([
+            'name' => 'Three',
+            'order' => 3,
+            'depth' => 1,
+        ]);
+
+        $newParentEligibility = factory(Taxonomy::class)->create([
+            'name' => 'New Service Eligibility Type',
+            'parent_id' => function () {
+                return Taxonomy::serviceEligibility()->id;
+            },
+        ]);
+        $newEligibilityOne = $newParentEligibility->children()->create([
+            'name' => 'One',
+            'order' => 1,
+            'depth' => 1,
+        ]);
+        $newEligibilityTwo = $newParentEligibility->children()->create([
+            'name' => 'Two',
+            'order' => 2,
+            'depth' => 1,
+        ]);
+        $newEligibilityThree = $newParentEligibility->children()->create([
+            'name' => 'Three',
+            'order' => 3,
+            'depth' => 1,
+        ]);
+
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$oldEligibilityTwo->id}", [
+            'parent_id' => $newParentEligibility->id,
+            'name' => $oldEligibilityTwo->name,
+            'order' => 4,
+        ]);
+
+        $response->assertStatus(Response::HTTP_OK);
+
+        /*
+         * Old parent.
+         */
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), [
+            'parent_id' => $this->testserviceEligibilityType->id,
+            'id' => $oldEligibilityOne->id,
+            'order' => 1,
+        ]);
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), [
+            'parent_id' => $this->testserviceEligibilityType->id,
+            'id' => $oldEligibilityThree->id,
+            'order' => 2,
+        ]);
+
+        /*
+         * New parent.
+         */
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), [
+            'parent_id' => $newParentEligibility->id,
+            'id' => $newEligibilityOne->id,
+            'order' => 1,
+        ]);
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), [
+            'parent_id' => $newParentEligibility->id,
+            'id' => $newEligibilityTwo->id,
+            'order' => 2,
+        ]);
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), [
+            'parent_id' => $newParentEligibility->id,
+            'id' => $newEligibilityThree->id,
+            'order' => 3,
+        ]);
+        $this->assertDatabaseHas((new Taxonomy())->getTable(), [
+            'parent_id' => $newParentEligibility->id,
+            'id' => $oldEligibilityTwo->id,
+            'order' => 4,
+        ]);
+    }
+
+    public function test_order_cannot_be_less_than_1_when_updated()
+    {
+        $user = factory(User::class)->create()->makeSuperAdmin();
+        Passport::actingAs($user);
+
+        $testEligibilityTypeTaxonomy = factory(Taxonomy::class)->create([
+            'parent_id' => $this->testserviceEligibilityType->id,
+        ]);
+
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}", [
+            'parent_id' => $testEligibilityTypeTaxonomy->parent_id,
+            'name' => $testEligibilityTypeTaxonomy->name,
+            'order' => 0,
+        ]);
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    public function test_order_cannot_be_greater_than_count_plus_1_when_updated()
+    {
+        $user = factory(User::class)->create()->makeSuperAdmin();
+        Passport::actingAs($user);
+
+        $testEligibilityTypeTaxonomies = factory(Taxonomy::class, 5)->create([
+            'parent_id' => $this->testserviceEligibilityType->id,
+        ]);
+
+        $response = $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomies->get(0)->id}", [
+            'parent_id' => $this->testserviceEligibilityType->id,
+            'name' => $testEligibilityTypeTaxonomies->get(0)->name,
+            'order' => 6,
+        ]);
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    public function test_audit_created_when_updated()
+    {
+        $this->fakeEvents();
+
+        $user = factory(User::class)->create()->makeSuperAdmin();
+        $testEligibilityTypeTaxonomy = factory(Taxonomy::class)->create([
+            'parent_id' => $this->testserviceEligibilityType->id,
+        ]);
+
+        Passport::actingAs($user);
+        $this->json('PUT', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}", [
+            'parent_id' => $testEligibilityTypeTaxonomy->parent_id,
+            'name' => 'PHPUnit Test Eligibility Type Taxonomy',
+            'order' => $testEligibilityTypeTaxonomy->order,
+        ]);
+
+        Event::assertDispatched(EndpointHit::class, function (EndpointHit $event) use ($user, $testEligibilityTypeTaxonomy) {
+            return ($event->getAction() === Audit::ACTION_UPDATE) &&
+                ($event->getUser()->id === $user->id) &&
+                ($event->getModel()->id === $testEligibilityTypeTaxonomy->id);
+        });
+    }
+
+    /*
+     * Delete a specific category taxonomy.
+     */
+
+    public function test_guest_cannot_delete_one()
+    {
+        $testEligibilityTypeTaxonomy = factory(Taxonomy::class)->create([
+            'parent_id' => $this->testserviceEligibilityType->id,
+        ]);
+
+        $response = $this->json('DELETE', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}");
+
+        $response->assertStatus(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function test_service_worker_cannot_delete_one()
+    {
+        $service = factory(Service::class)->create();
+        $user = factory(User::class)->create()->makeServiceWorker($service);
+        $testEligibilityTypeTaxonomy = factory(Taxonomy::class)->create([
+            'parent_id' => $this->testserviceEligibilityType->id,
+        ]);
+
+        Passport::actingAs($user);
+        $response = $this->json('DELETE', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}");
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_service_admin_cannot_delete_one()
+    {
+        $service = factory(Service::class)->create();
+        $user = factory(User::class)->create()->makeServiceAdmin($service);
+        $testEligibilityTypeTaxonomy = factory(Taxonomy::class)->create([
+            'parent_id' => $this->testserviceEligibilityType->id,
+        ]);
+
+        Passport::actingAs($user);
+        $response = $this->json('DELETE', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}");
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_organisation_admin_cannot_delete_one()
+    {
+        $organisation = factory(Organisation::class)->create();
+        $user = factory(User::class)->create()->makeOrganisationAdmin($organisation);
+        $testEligibilityTypeTaxonomy = factory(Taxonomy::class)->create([
+            'parent_id' => $this->testserviceEligibilityType->id,
+        ]);
+
+        Passport::actingAs($user);
+        $response = $this->json('DELETE', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}");
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_global_admin_can_delete_one()
+    {
+        $user = factory(User::class)->create()->makeGlobalAdmin();
+        $newParentEligibility = factory(Taxonomy::class)->create([
+            'name' => 'New Service Eligibility Type',
+            'parent_id' => function () {
+                return Taxonomy::serviceEligibility()->id;
+            },
+        ]);
+        $childEligibilities = factory(Taxonomy::class)->create([
+            'parent_id' => $newParentEligibility->id,
+        ]);
+
+        Passport::actingAs($user);
+        $response = $this->json('DELETE', "/core/v1/taxonomies/service-eligibility/{$newParentEligibility->id}");
+
+        $response->assertStatus(Response::HTTP_OK);
+        $this->assertDatabaseMissing((new Taxonomy())->getTable(), ['id' => $newParentEligibility->id]);
+        foreach ($childEligibilities as $childEligibility) {
+            $this->assertDatabaseMissing((new Taxonomy())->getTable(), ['id' => $childEligibility->id]);
+        }
+    }
+
+    public function test_audit_created_when_deleted()
+    {
+        $this->fakeEvents();
+
+        $user = factory(User::class)->create()->makeGlobalAdmin();
+        $newParentEligibility = factory(Taxonomy::class)->create([
+            'name' => 'New Service Eligibility Type',
+            'parent_id' => function () {
+                return Taxonomy::serviceEligibility()->id;
+            },
+        ]);
+        factory(Taxonomy::class)->create([
+            'parent_id' => $newParentEligibility->id,
+        ]);
+
+        Passport::actingAs($user);
+        $this->json('DELETE', "/core/v1/taxonomies/service-eligibility/{$newParentEligibility->id}");
+
+        Event::assertDispatched(EndpointHit::class, function (EndpointHit $event) use ($user, $newParentEligibility) {
+            return ($event->getAction() === Audit::ACTION_DELETE) &&
+                ($event->getUser()->id === $user->id) &&
+                ($event->getModel()->id === $newParentEligibility->id);
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function service_eligibility_relationships_are_destroyed_when_deleted()
+    {
+        $user = factory(User::class)->create()->makeGlobalAdmin();
+        $service = factory(Service::class)->create();
+        $testEligibilityTypeTaxonomy = factory(Taxonomy::class)->create([
+            'parent_id' => $this->testserviceEligibilityType->id,
+        ]);
+
+        $service->serviceEligibilities()->create([
+            'taxonomy_id' => $testEligibilityTypeTaxonomy->id,
+        ]);
+
+        $this->assertDatabaseHas((new ServiceEligibility())->getTable(), [
+            'service_id' => $service->id,
+            'taxonomy_id' => $testEligibilityTypeTaxonomy->id,
+        ]);
+
+        Passport::actingAs($user);
+        $response = $this->json('DELETE', "/core/v1/taxonomies/service-eligibility/{$testEligibilityTypeTaxonomy->id}");
+
+        $response->assertStatus(Response::HTTP_OK);
+        $this->assertDatabaseMissing((new ServiceEligibility())->getTable(), [
+            'service_id' => $service->id,
+            'taxonomy_id' => $testEligibilityTypeTaxonomy->id,
+        ]);
     }
 }


### PR DESCRIPTION
### Summary

https://app.clubhouse.io/ayup-digital-ltd/story/517/endpoints-to-update-eligibility-taxonomies

Created CRUD endpoints for Service Eligibility taxonomies

### Development checklist

- [x] Changes have been made to the API?
  - [x] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

NA

### Notes

NA
