### PR TITLE
Feature/hounslow ch655 search optimisation tweaks

### DIFF
--- a/app/Http/Controllers/Core/V1/SearchController.php
+++ b/app/Http/Controllers/Core/V1/SearchController.php
@@ -47,7 +47,7 @@ class SearchController extends Controller
             );
 
             // Apply radius filtering.
-            $search->applyRadius($location, $request->radius ?? config('ck.search_distance'));
+            $search->applyRadius($location, $request->input('distance', config('ck.search_distance')));
         }
 
         if ($request->has('eligibilities')) {

--- a/app/Search/ElasticsearchSearch.php
+++ b/app/Search/ElasticsearchSearch.php
@@ -71,10 +71,10 @@ class ElasticsearchSearch implements Search
         $should = &$this->query['query']['bool']['must']['bool']['should'];
 
         $should[] = $this->match('name', $term, 4);
+        $should[] = $this->match('organisation_name', $term, 4);
         $should[] = $this->match('intro', $term, 3);
         $should[] = $this->matchPhrase('description', $term, 3);
         $should[] = $this->match('taxonomy_categories', $term, 2);
-        $should[] = $this->match('organisation_name', $term);
 
         return $this;
     }

--- a/app/Search/ElasticsearchSearch.php
+++ b/app/Search/ElasticsearchSearch.php
@@ -70,11 +70,15 @@ class ElasticsearchSearch implements Search
     {
         $should = &$this->query['query']['bool']['must']['bool']['should'];
 
-        $should[] = $this->match('name', $term, 4);
-        $should[] = $this->match('organisation_name', $term, 4);
-        $should[] = $this->match('intro', $term, 3);
-        $should[] = $this->matchPhrase('description', $term, 3);
-        $should[] = $this->match('taxonomy_categories', $term, 2);
+        $should[] = $this->match('name', $term, 3);
+        $should[] = $this->match('organisation_name', $term, 3);
+        $should[] = $this->match('intro', $term, 2);
+        $should[] = $this->matchPhrase('description', $term, 1.5);
+        $should[] = $this->match('taxonomy_categories', $term);
+
+        if (empty($this->query['query']['bool']['must']['bool']['minimum_should_match'])) {
+            $this->query['query']['bool']['must']['bool']['minimum_should_match'] = 1;
+        }
 
         return $this;
     }
@@ -297,6 +301,12 @@ class ElasticsearchSearch implements Search
                     ],
                 ];
 
+                if (empty($this->query['query']['bool']['must']['bool']['minimum_should_match'])) {
+                    $this->query['query']['bool']['must']['bool']['minimum_should_match'] = 1;
+                } else {
+                    $this->query['query']['bool']['must']['bool']['minimum_should_match']++;
+                }
+
                 foreach ($serviceEligibilityTypeNames as $serviceEligibilityTypeName) {
                     $this->query['query']['bool']['must']['bool']['should'][] = [
                         'term' => [
@@ -311,7 +321,7 @@ class ElasticsearchSearch implements Search
                     'match' => [
                         'service_eligibilities' => [
                             'query' => $serviceEligibilityTypeAllName,
-                            'boost' => 0.2,
+                            'boost' => 0,
                         ],
                     ],
                 ];


### PR DESCRIPTION
### Summary

https://app.clubhouse.io/ayup-digital-ltd/story/655/search-optimisation-tweaks

- Prevent long tail results in collection / persona queries
- Fix location distance query param
- Give organisation name and service name weight parity
- Eligibility filters apply only to query result set through minimum_should_match
- Add tests to confirm acceptance criteria

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

NA

### Notes

Previously merged into master via PR#86 then reverted via PR#88
