### PR TITLE
Added attributes when signing up to exisiting organisation

### DIFF
--- a/app/Http/Controllers/Core/V1/OrganisationSignUpFormController.php
+++ b/app/Http/Controllers/Core/V1/OrganisationSignUpFormController.php
@@ -6,6 +6,7 @@ use App\Events\EndpointHit;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\OrganisationSignUpForm\StoreRequest;
 use App\Http\Responses\UpdateRequestReceived;
+use App\Models\Organisation;
 use App\Models\UpdateRequest;
 use Illuminate\Http\Response;
 use Illuminate\Support\Arr;
@@ -40,7 +41,10 @@ class OrganisationSignUpFormController extends Controller
 
             $updateData['organisation'] = [];
             if ($request->filled('organisation.id')) {
-                $updateData['organisation']['id'] = $request->input('organisation.id');
+                $organisation = Organisation::find($request->input('organisation.id'));
+                $updateData['organisation'] = array_filter($organisation->attributesToArray(), function ($key) {
+                    return in_array($key, ['id', 'slug', 'name', 'description', 'url', 'email', 'phone']);
+                }, ARRAY_FILTER_USE_KEY);
             } else {
                 $updateData['organisation'] = [
                     'slug' => $request->input('organisation.slug'),

--- a/tests/Feature/OrganisationSignUpFormTest.php
+++ b/tests/Feature/OrganisationSignUpFormTest.php
@@ -164,6 +164,12 @@ class OrganisationSignUpFormTest extends TestCase
 
         $this->assertEquals($userSubmission['email'], $this->getResponseContent($response, 'data.user.email'));
         $this->assertEquals($organisation->id, $this->getResponseContent($response, 'data.organisation.id'));
+        $this->assertEquals($organisation->slug, $this->getResponseContent($response, 'data.organisation.slug'));
+        $this->assertEquals($organisation->name, $this->getResponseContent($response, 'data.organisation.name'));
+        $this->assertEquals($organisation->description, $this->getResponseContent($response, 'data.organisation.description'));
+        $this->assertEquals($organisation->url, $this->getResponseContent($response, 'data.organisation.url'));
+        $this->assertEquals($organisation->email, $this->getResponseContent($response, 'data.organisation.email'));
+        $this->assertEquals($organisation->phone, $this->getResponseContent($response, 'data.organisation.phone'));
 
         Event::assertDispatched(EndpointHit::class, function (EndpointHit $event) use ($response) {
             /** @var \App\Models\UpdateRequest $updateRequest */
@@ -229,7 +235,7 @@ class OrganisationSignUpFormTest extends TestCase
         $response->assertStatus(Response::HTTP_CREATED);
 
         $this->assertEquals($userSubmission['email'], $this->getResponseContent($response, 'data.user.email'));
-        $this->assertEquals($organisationSubmission['email'], $this->getResponseContent($response, 'data.organisation.email'));
+        $this->assertEquals($organisationSubmission, $this->getResponseContent($response, 'data.organisation'));
 
         Event::assertDispatched(EndpointHit::class, function (EndpointHit $event) use ($response) {
             /** @var \App\Models\UpdateRequest $updateRequest */


### PR DESCRIPTION
### Summary

https://app.clubhouse.io/ayup-digital-ltd/story/765/organisation-sign-up-received-approve-and-rejected-emails-not-working

Organisation attributes were not passed to the email template when the user was signing up to an existing organisation.

Existing organisation attributes now passed to the email template.

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

NA

### Notes

NA
