### PR TITLE
Moved management of logo files from creation to applying update requests

### DIFF
--- a/app/Services/DataPersistence/ServicePersistenceService.php
+++ b/app/Services/DataPersistence/ServicePersistenceService.php
@@ -17,8 +17,8 @@ class ServicePersistenceService implements DataPersistenceService
     public function store(FormRequest $request)
     {
         return $request->user()->isGlobalAdmin()
-            ? $this->processAsNewEntity($request)
-            : $this->processAsUpdateRequest($request);
+        ? $this->processAsNewEntity($request)
+        : $this->processAsUpdateRequest($request);
     }
 
     public function update(FormRequest $request, Model $model)
@@ -63,27 +63,27 @@ class ServicePersistenceService implements DataPersistenceService
                 'logo_file_id' => $request->missing('logo_file_id'),
             ]);
 
-            if ($request->filled('gallery_items') && !$request->isPreview()) {
-                foreach ($request->gallery_items as $galleryItem) {
-                    /** @var \App\Models\File $file */
-                    $file = File::findOrFail($galleryItem['file_id'])->assigned();
+            // if ($request->filled('gallery_items') && !$request->isPreview()) {
+            //     foreach ($request->gallery_items as $galleryItem) {
+            //         /** @var \App\Models\File $file */
+            //         $file = File::findOrFail($galleryItem['file_id'])->assigned();
 
-                    // Create resized version for common dimensions.
-                    foreach (config('ck.cached_image_dimensions') as $maxDimension) {
-                        $file->resizedVersion($maxDimension);
-                    }
-                }
-            }
+            //         // Create resized version for common dimensions.
+            //         foreach (config('ck.cached_image_dimensions') as $maxDimension) {
+            //             $file->resizedVersion($maxDimension);
+            //         }
+            //     }
+            // }
 
-            if ($request->filled('logo_file_id') && !$request->isPreview()) {
-                /** @var \App\Models\File $file */
-                $file = File::findOrFail($request->logo_file_id)->assigned();
+            // if ($request->filled('logo_file_id') && !$request->isPreview()) {
+            //     /** @var \App\Models\File $file */
+            //     $file = File::findOrFail($request->logo_file_id)->assigned();
 
-                // Create resized version for common dimensions.
-                foreach (config('ck.cached_image_dimensions') as $maxDimension) {
-                    $file->resizedVersion($maxDimension);
-                }
-            }
+            //     // Create resized version for common dimensions.
+            //     foreach (config('ck.cached_image_dimensions') as $maxDimension) {
+            //         $file->resizedVersion($maxDimension);
+            //     }
+            // }
 
             // Loop through each useful info.
             foreach ($request->input('useful_infos', []) as $usefulInfo) {

--- a/tests/Feature/UpdateRequestsTest.php
+++ b/tests/Feature/UpdateRequestsTest.php
@@ -9,7 +9,6 @@ use App\Models\Offering;
 use App\Models\Organisation;
 use App\Models\Role;
 use App\Models\Service;
-use App\Models\ServiceCriterion;
 use App\Models\ServiceLocation;
 use App\Models\SocialMedia;
 use App\Models\Taxonomy;
@@ -17,7 +16,6 @@ use App\Models\UpdateRequest;
 use App\Models\UsefulInfo;
 use App\Models\User;
 use App\Models\UserRole;
-use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Date;
@@ -733,6 +731,21 @@ class UpdateRequestsTest extends TestCase
         //Given an organisation admin is logged in
         Passport::actingAs($user);
 
+        $imagePayload = [
+            'is_private' => false,
+            'mime_type' => 'image/png',
+            'file' => 'data:image/png;base64,' . self::BASE64_ENCODED_PNG,
+        ];
+
+        $response = $this->json('POST', '/core/v1/files', $imagePayload);
+        $logoImage = $this->getResponseContent($response, 'data');
+
+        $response = $this->json('POST', '/core/v1/files', $imagePayload);
+        $galleryImage1 = $this->getResponseContent($response, 'data');
+
+        $response = $this->json('POST', '/core/v1/files', $imagePayload);
+        $galleryImage2 = $this->getResponseContent($response, 'data');
+
         $payload = [
             'organisation_id' => $organisation->id,
             'slug' => 'test-service',
@@ -769,7 +782,15 @@ class UpdateRequestsTest extends TestCase
                     'order' => 1,
                 ],
             ],
-            'gallery_items' => [],
+            'logo_file_id' => $logoImage['id'],
+            'gallery_items' => [
+                [
+                    'file_id' => $galleryImage1['id'],
+                ],
+                [
+                    'file_id' => $galleryImage2['id'],
+                ],
+            ],
             'category_taxonomies' => [],
         ];
 


### PR DESCRIPTION
### Summary

https://app.clubhouse.io/ayup-digital-ltd/story/828/when-adding-a-new-service-with-a-logo-gallery-images-the-associated-update-request-can-t-be-approved

Moved the management of logo and gallery image files from the update request creation to applying the update request. This prevent the "The xxx must be an unassigned file" errors as the files were being assigned and additional sizes created before the update request was accepted.

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

NA

### Notes

NA
