### PR TITLE
Removed python version so will use Travis default, currently 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ branches:
     - develop
 
 language: python
-python:
-  - "2.7"
 
 services:
   - docker


### PR DESCRIPTION
### Summary

Amazon AWS have increased their minimum Python version to 3.6 (https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/) so the Travis pipeline needs to be updated to match.

The tagged Python version has been removed from travis.yml, this will allow Travis to use it's default Python runtime, currently 3.6, which will meet AWS requirements.

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [ ] The code has been linted `./develop composer fix:style`

### Release checklist

NA

### Notes

NA
