### PR TITLE
Feature/update travis python version to meet aws requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,9 @@ before_deploy: |
     ./develop npm run prod
 
     echo "Installing AWS CLI..."
-    curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
-    unzip awscli-bundle.zip
-    sudo ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+    unzip awscliv2.zip
+    sudo ./aws/install -i /usr/local/aws -b /usr/local/bin/aws
   fi
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ branches:
     - develop
 
 language: python
-python:
-  - "2.7"
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ branches:
 
 language: python
 
+python:
+  - "3.6"
+
 services:
   - docker
 


### PR DESCRIPTION
### Summary

Migrated to AWS CLI v2 as Travis seemed to be unwilling to bump the python version from 2.7 to 3.6, or AWS CLI v1 was unable to detect the change. This may have been a caching issue, but as AWS advises a move to v2 anyway it seemed appropriate.

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [ ] The code has been linted `./develop composer fix:style`

### Release checklist

NA

### Notes

NA
