### PR TITLE
Updated organisation sign up form rules to ignore exisiting slug

### DIFF
--- a/app/Http/Requests/OrganisationSignUpForm/StoreRequest.php
+++ b/app/Http/Requests/OrganisationSignUpForm/StoreRequest.php
@@ -72,7 +72,8 @@ class StoreRequest extends FormRequest
                 'string',
                 'min:1',
                 'max:255',
-                'unique:' . table(Organisation::class) . ',slug',
+                Rule::unique(table(Organisation::class), 'slug')
+                    ->ignore($this->input('organisation.id')),
                 new Slug(),
             ],
             'organisation.name' => ['required_without:organisation.id', 'nullable', 'string', 'min:1', 'max:255'],

--- a/app/Models/UpdateRequest.php
+++ b/app/Models/UpdateRequest.php
@@ -123,8 +123,8 @@ class UpdateRequest extends Model
     public function getUpdateable(): AppliesUpdateRequests
     {
         return $this->isExisting()
-            ? $this->updateable
-            : $this->createUpdateableInstance();
+        ? $this->updateable
+        : $this->createUpdateableInstance();
     }
 
     /**


### PR DESCRIPTION
### Summary

https://app.clubhouse.io/ayup-digital-ltd/story/830/new-organisation-sign-up-form-update-requests-can-not-be-approved

Changed update request validation to ignore slug of updating model

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

NA

### Notes

NA
